### PR TITLE
Migrate loader blocking to threat disposition & optimize scan startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ LOCAL_DEV_GUIDE.md
 nexuspost.bbcode
 TS-Post.md
 ENVIRONMENT_INTEGRATION_GUIDE.md
+bump-version.ps1

--- a/BepInEx/5/BepInEx5Patcher.cs
+++ b/BepInEx/5/BepInEx5Patcher.cs
@@ -94,6 +94,7 @@ namespace MLVScan.BepInEx5
                         if (!config.ReportUploadConsentAsked)
                         {
                             config.ReportUploadConsentAsked = true;
+                            config.PendingReportUploadVerdictKind = disabledPlugins[0].ThreatVerdict?.Kind.ToString() ?? string.Empty;
                             configManager.SaveConfig(config);
                             _logger.LogInfo("MLVScan can optionally send reports to the API to help fix false positives.");
                             _logger.LogInfo("To enable: set EnableReportUpload = true in BepInEx/config/MLVScan.json");
@@ -101,7 +102,7 @@ namespace MLVScan.BepInEx5
 
                         reportGenerator.GenerateReports(disabledPlugins, scanResults);
 
-                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} suspicious plugin(s).");
+                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
                         _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                     }
                 }
@@ -111,7 +112,7 @@ namespace MLVScan.BepInEx5
                 }
                 else
                 {
-                    _logger.LogInfo("No suspicious plugins detected.");
+                    _logger.LogInfo("No flagged plugins detected.");
                 }
 
                 _logger.LogInfo("MLVScan preloader scan complete.");

--- a/BepInEx/5/BepInEx5Patcher.cs
+++ b/BepInEx/5/BepInEx5Patcher.cs
@@ -87,10 +87,9 @@ namespace MLVScan.BepInEx5
 
                 if (scanResults.Count > 0)
                 {
-                    // Disable suspicious plugins
                     var disabledPlugins = pluginDisabler.DisableSuspiciousPlugins(scanResults);
+                    var reviewOnlyCount = scanResults.Count - disabledPlugins.Count;
 
-                    // Generate reports for disabled plugins
                     if (disabledPlugins.Count > 0)
                     {
                         // First-run consent fallback for BepInEx 5.
@@ -102,12 +101,21 @@ namespace MLVScan.BepInEx5
                             _logger.LogInfo("MLVScan can optionally send reports to the API to help fix false positives.");
                             _logger.LogInfo("To enable: set EnableReportUpload = true in BepInEx/config/MLVScan.json");
                         }
-
-                        reportGenerator.GenerateReports(disabledPlugins, scanResults);
-
-                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
-                        _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                     }
+
+                    reportGenerator.GenerateReports(disabledPlugins, scanResults);
+
+                    if (disabledPlugins.Count > 0)
+                    {
+                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} plugin(s).");
+                    }
+
+                    if (reviewOnlyCount > 0)
+                    {
+                        _logger.LogWarning($"MLVScan flagged {reviewOnlyCount} plugin(s) for manual review without blocking them.");
+                    }
+
+                    _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                 }
                 else if (!config.EnableAutoScan)
                 {
@@ -115,7 +123,7 @@ namespace MLVScan.BepInEx5
                 }
                 else
                 {
-                    _logger.LogInfo("No flagged plugins detected.");
+                    _logger.LogInfo("No plugins requiring action were detected.");
                 }
 
                 _logger.LogInfo("MLVScan preloader scan complete.");

--- a/BepInEx/5/BepInEx5Patcher.cs
+++ b/BepInEx/5/BepInEx5Patcher.cs
@@ -5,6 +5,7 @@ using BepInEx.Logging;
 using Mono.Cecil;
 using MLVScan.BepInEx;
 using MLVScan.BepInEx.Adapters;
+using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.BepInEx5
 {
@@ -59,6 +60,7 @@ namespace MLVScan.BepInEx5
 
                 // Create platform environment
                 var environment = new BepInExPlatformEnvironment();
+                var telemetry = new LoaderScanTelemetryHub();
 
                 // Load or create configuration
                 var configManager = new BepInExConfigManager(_logger, DefaultWhitelistedHashes);
@@ -66,7 +68,7 @@ namespace MLVScan.BepInEx5
 
                 // Create adapters
                 var scanLogger = new BepInExScanLogger(_logger);
-                var resolverProvider = new BepInExAssemblyResolverProvider();
+                var resolverProvider = new BepInExAssemblyResolverProvider(telemetry);
 
                 // Create scanner and disabler
                 var pluginScanner = new BepInExPluginScanner(
@@ -74,7 +76,8 @@ namespace MLVScan.BepInEx5
                     resolverProvider,
                     config,
                     configManager,
-                    environment);
+                    environment,
+                    telemetry);
 
                 var pluginDisabler = new BepInExPluginDisabler(scanLogger, config);
                 var reportGenerator = new BepInExReportGenerator(_logger, config, configManager.GetReportUploadApiBaseUrl(), configManager);

--- a/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
+++ b/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
@@ -5,6 +5,7 @@ using BepInEx.Logging;
 using BepInEx.Preloader.Core.Patching;
 using MLVScan.BepInEx;
 using MLVScan.BepInEx.Adapters;
+using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.BepInEx6.IL2CPP
 {
@@ -51,6 +52,7 @@ namespace MLVScan.BepInEx6.IL2CPP
 
                 // Create platform environment
                 var environment = new BepInExPlatformEnvironment();
+                var telemetry = new LoaderScanTelemetryHub();
 
                 // Load or create configuration
                 var configManager = new BepInExConfigManager(_logger, DefaultWhitelistedHashes);
@@ -58,7 +60,7 @@ namespace MLVScan.BepInEx6.IL2CPP
 
                 // Create adapters
                 var scanLogger = new BepInExScanLogger(_logger);
-                var resolverProvider = new BepInExAssemblyResolverProvider();
+                var resolverProvider = new BepInExAssemblyResolverProvider(telemetry);
 
                 // Create scanner and disabler
                 var pluginScanner = new BepInExPluginScanner(
@@ -66,7 +68,8 @@ namespace MLVScan.BepInEx6.IL2CPP
                     resolverProvider,
                     config,
                     configManager,
-                    environment);
+                    environment,
+                    telemetry);
 
                 var pluginDisabler = new BepInExPluginDisabler(scanLogger, config);
                 var reportGenerator = new BepInExReportGenerator(_logger, config, configManager.GetReportUploadApiBaseUrl(), configManager);

--- a/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
+++ b/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
@@ -79,10 +79,9 @@ namespace MLVScan.BepInEx6.IL2CPP
 
                 if (scanResults.Count > 0)
                 {
-                    // Disable suspicious plugins
                     var disabledPlugins = pluginDisabler.DisableSuspiciousPlugins(scanResults);
+                    var reviewOnlyCount = scanResults.Count - disabledPlugins.Count;
 
-                    // Generate reports for disabled plugins
                     if (disabledPlugins.Count > 0)
                     {
                         // Queue first-run GUI consent for runtime plugin.
@@ -96,12 +95,21 @@ namespace MLVScan.BepInEx6.IL2CPP
                             configManager.SaveConfig(config);
                             _logger.LogInfo("MLVScan will show an in-game upload consent popup.");
                         }
-
-                        reportGenerator.GenerateReports(disabledPlugins, scanResults);
-
-                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
-                        _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                     }
+
+                    reportGenerator.GenerateReports(disabledPlugins, scanResults);
+
+                    if (disabledPlugins.Count > 0)
+                    {
+                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} plugin(s).");
+                    }
+
+                    if (reviewOnlyCount > 0)
+                    {
+                        _logger.LogWarning($"MLVScan flagged {reviewOnlyCount} plugin(s) for manual review without blocking them.");
+                    }
+
+                    _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                 }
                 else if (!config.EnableAutoScan)
                 {
@@ -109,7 +117,7 @@ namespace MLVScan.BepInEx6.IL2CPP
                 }
                 else
                 {
-                    _logger.LogInfo("No flagged plugins detected.");
+                    _logger.LogInfo("No plugins requiring action were detected.");
                 }
 
                 _logger.LogInfo("MLVScan BepInEx 6 (IL2CPP) preloader scan complete.");

--- a/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
+++ b/BepInEx/6/IL2CPP/BepInEx6IL2CppPatcher.cs
@@ -89,13 +89,14 @@ namespace MLVScan.BepInEx6.IL2CPP
                             config.ReportUploadConsentPending = true;
                             config.PendingReportUploadPath =
                                 File.Exists(firstDisabled.DisabledPath) ? firstDisabled.DisabledPath : firstDisabled.OriginalPath;
+                            config.PendingReportUploadVerdictKind = firstDisabled.ThreatVerdict?.Kind.ToString() ?? string.Empty;
                             configManager.SaveConfig(config);
                             _logger.LogInfo("MLVScan will show an in-game upload consent popup.");
                         }
 
                         reportGenerator.GenerateReports(disabledPlugins, scanResults);
 
-                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} suspicious plugin(s).");
+                        _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
                         _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                     }
                 }
@@ -105,7 +106,7 @@ namespace MLVScan.BepInEx6.IL2CPP
                 }
                 else
                 {
-                    _logger.LogInfo("No suspicious plugins detected.");
+                    _logger.LogInfo("No flagged plugins detected.");
                 }
 
                 _logger.LogInfo("MLVScan BepInEx 6 (IL2CPP) preloader scan complete.");

--- a/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
+++ b/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
@@ -5,6 +5,7 @@ using BepInEx.Logging;
 using BepInEx.Preloader.Core.Patching;
 using MLVScan.BepInEx;
 using MLVScan.BepInEx.Adapters;
+using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.BepInEx6.Mono
 {
@@ -51,6 +52,7 @@ namespace MLVScan.BepInEx6.Mono
 
                 // Create platform environment
                 var environment = new BepInExPlatformEnvironment();
+                var telemetry = new LoaderScanTelemetryHub();
 
                 // Load or create configuration
                 var configManager = new BepInExConfigManager(_logger, DefaultWhitelistedHashes);
@@ -58,7 +60,7 @@ namespace MLVScan.BepInEx6.Mono
 
                 // Create adapters
                 var scanLogger = new BepInExScanLogger(_logger);
-                var resolverProvider = new BepInExAssemblyResolverProvider();
+                var resolverProvider = new BepInExAssemblyResolverProvider(telemetry);
 
                 // Create scanner and disabler
                 var pluginScanner = new BepInExPluginScanner(
@@ -66,7 +68,8 @@ namespace MLVScan.BepInEx6.Mono
                     resolverProvider,
                     config,
                     configManager,
-                    environment);
+                    environment,
+                    telemetry);
 
                 var pluginDisabler = new BepInExPluginDisabler(scanLogger, config);
                 var reportGenerator = new BepInExReportGenerator(_logger, config, configManager.GetReportUploadApiBaseUrl(), configManager);

--- a/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
+++ b/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
@@ -85,6 +85,7 @@ namespace MLVScan.BepInEx6.Mono
                     if (scanResults.Count > 0)
                     {
                         var disabledPlugins = pluginDisabler.DisableSuspiciousPlugins(scanResults);
+                        var reviewOnlyCount = scanResults.Count - disabledPlugins.Count;
 
                         if (disabledPlugins.Count > 0)
                         {
@@ -99,16 +100,25 @@ namespace MLVScan.BepInEx6.Mono
                                 configManager.SaveConfig(config);
                                 _logger.LogInfo("MLVScan will show an in-game upload consent popup.");
                             }
-
-                            reportGenerator.GenerateReports(disabledPlugins, scanResults);
-
-                            _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
-                            _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                         }
+
+                        reportGenerator.GenerateReports(disabledPlugins, scanResults);
+
+                        if (disabledPlugins.Count > 0)
+                        {
+                            _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} plugin(s).");
+                        }
+
+                        if (reviewOnlyCount > 0)
+                        {
+                            _logger.LogWarning($"MLVScan flagged {reviewOnlyCount} plugin(s) for manual review without blocking them.");
+                        }
+
+                        _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                     }
                     else
                     {
-                        _logger.LogInfo("No flagged plugins detected.");
+                        _logger.LogInfo("No plugins requiring action were detected.");
                     }
                 }
 

--- a/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
+++ b/BepInEx/6/Mono/BepInEx6MonoPatcher.cs
@@ -92,19 +92,20 @@ namespace MLVScan.BepInEx6.Mono
                                 config.ReportUploadConsentPending = true;
                                 config.PendingReportUploadPath =
                                     File.Exists(firstDisabled.DisabledPath) ? firstDisabled.DisabledPath : firstDisabled.OriginalPath;
+                                config.PendingReportUploadVerdictKind = firstDisabled.ThreatVerdict?.Kind.ToString() ?? string.Empty;
                                 configManager.SaveConfig(config);
                                 _logger.LogInfo("MLVScan will show an in-game upload consent popup.");
                             }
 
                             reportGenerator.GenerateReports(disabledPlugins, scanResults);
 
-                            _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} suspicious plugin(s).");
+                            _logger.LogWarning($"MLVScan blocked {disabledPlugins.Count} flagged plugin(s).");
                             _logger.LogWarning("Check BepInEx/MLVScan/Reports/ for details.");
                         }
                     }
                     else
                     {
-                        _logger.LogInfo("No suspicious plugins detected.");
+                        _logger.LogInfo("No flagged plugins detected.");
                     }
                 }
 

--- a/BepInEx/Adapters/BepInExAssemblyResolverProvider.cs
+++ b/BepInEx/Adapters/BepInExAssemblyResolverProvider.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using BepInEx;
-using MLVScan.Abstractions;
-using Mono.Cecil;
+using MLVScan.Services.Diagnostics;
+using MLVScan.Services.Resolution;
 
 namespace MLVScan.BepInEx.Adapters
 {
@@ -10,36 +11,40 @@ namespace MLVScan.BepInEx.Adapters
     /// Provides assembly resolution for scanning in BepInEx context.
     /// Adds all relevant BepInEx and game directories to search paths.
     /// </summary>
-    public class BepInExAssemblyResolverProvider : IAssemblyResolverProvider
+    public class BepInExAssemblyResolverProvider : CatalogingAssemblyResolverProviderBase
     {
-        public IAssemblyResolver CreateResolver()
+        public BepInExAssemblyResolverProvider()
+            : base()
         {
-            var resolver = new DefaultAssemblyResolver();
+        }
+
+        protected override IEnumerable<ResolverRoot> GetStableRoots()
+        {
+            var roots = new List<ResolverRoot>();
 
             try
             {
-                // Game's managed assemblies (Unity DLLs, game code)
                 if (Directory.Exists(Paths.ManagedPath))
-                    resolver.AddSearchDirectory(Paths.ManagedPath);
+                {
+                    roots.Add(new ResolverRoot(Paths.ManagedPath, 0));
+                }
 
-                // BepInEx core assemblies
                 if (Directory.Exists(Paths.BepInExAssemblyDirectory))
-                    resolver.AddSearchDirectory(Paths.BepInExAssemblyDirectory);
+                {
+                    roots.Add(new ResolverRoot(Paths.BepInExAssemblyDirectory, 5));
+                }
 
-                // Plugin directory (for plugin-to-plugin references)
-                if (Directory.Exists(Paths.PluginPath))
-                    resolver.AddSearchDirectory(Paths.PluginPath);
-
-                // Patcher directory (where we are running from)
                 if (Directory.Exists(Paths.PatcherPluginPath))
-                    resolver.AddSearchDirectory(Paths.PatcherPluginPath);
+                {
+                    roots.Add(new ResolverRoot(Paths.PatcherPluginPath, 10));
+                }
             }
             catch (Exception)
             {
-                // If path resolution fails, use default resolver behavior
+                return roots;
             }
 
-            return resolver;
+            return roots;
         }
     }
 }

--- a/BepInEx/Adapters/BepInExAssemblyResolverProvider.cs
+++ b/BepInEx/Adapters/BepInExAssemblyResolverProvider.cs
@@ -13,8 +13,8 @@ namespace MLVScan.BepInEx.Adapters
     /// </summary>
     public class BepInExAssemblyResolverProvider : CatalogingAssemblyResolverProviderBase
     {
-        public BepInExAssemblyResolverProvider()
-            : base()
+        public BepInExAssemblyResolverProvider(LoaderScanTelemetryHub telemetry)
+            : base(telemetry)
         {
         }
 

--- a/BepInEx/BepInExConfigManager.cs
+++ b/BepInEx/BepInExConfigManager.cs
@@ -64,8 +64,18 @@ namespace MLVScan.BepInEx
                     if (loaded != null)
                     {
                         _config = loaded;
-                        _config.WhitelistedHashes = NormalizeHashes(_config.WhitelistedHashes);
+                        var normalizedWhitelist = NormalizeHashes(_config.WhitelistedHashes);
+                        var mergedWhitelist = MergeWithDefaultWhitelistedHashes(normalizedWhitelist);
+
+                        _config.WhitelistedHashes = mergedWhitelist;
                         _config.UploadedReportHashes = NormalizeHashes(_config.UploadedReportHashes);
+
+                        if (!mergedWhitelist.SequenceEqual(normalizedWhitelist, StringComparer.OrdinalIgnoreCase))
+                        {
+                            SaveConfig(_config);
+                            _logger.LogInfo($"Added {mergedWhitelist.Length - normalizedWhitelist.Length} new default whitelist hash(es)");
+                        }
+
                         _logger.LogInfo("Configuration loaded from MLVScan.json");
                         return _config;
                     }
@@ -90,10 +100,12 @@ namespace MLVScan.BepInEx
             {
                 EnableAutoScan = true,
                 EnableAutoDisable = true,
+                BlockKnownThreats = true,
+                BlockSuspicious = true,
                 MinSeverityForDisable = Severity.Medium,
                 ScanDirectories = new[] { "plugins" },
                 SuspiciousThreshold = 1,
-                WhitelistedHashes = _defaultWhitelistedHashes,
+                WhitelistedHashes = MergeWithDefaultWhitelistedHashes(Array.Empty<string>()),
                 DumpFullIlReports = false,
                 Scan = new ScanConfig
                 {
@@ -103,6 +115,7 @@ namespace MLVScan.BepInEx
                 ReportUploadConsentAsked = false,
                 ReportUploadConsentPending = false,
                 PendingReportUploadPath = string.Empty,
+                PendingReportUploadVerdictKind = string.Empty,
                 ReportUploadApiBaseUrl = DefaultReportUploadApiBaseUrl,
                 UploadedReportHashes = Array.Empty<string>()
             };
@@ -197,6 +210,11 @@ namespace MLVScan.BepInEx
                 .Select(h => h.ToLowerInvariant())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToArray();
+        }
+
+        private string[] MergeWithDefaultWhitelistedHashes(System.Collections.Generic.IEnumerable<string> hashes)
+        {
+            return NormalizeHashes((hashes ?? Array.Empty<string>()).Concat(_defaultWhitelistedHashes ?? Array.Empty<string>()));
         }
     }
 }

--- a/BepInEx/BepInExConfigManager.cs
+++ b/BepInEx/BepInExConfigManager.cs
@@ -100,6 +100,7 @@ namespace MLVScan.BepInEx
             {
                 EnableAutoScan = true,
                 EnableAutoDisable = true,
+                EnableScanCache = true,
                 BlockKnownThreats = true,
                 BlockSuspicious = true,
                 MinSeverityForDisable = Severity.Medium,
@@ -117,7 +118,14 @@ namespace MLVScan.BepInEx
                 PendingReportUploadPath = string.Empty,
                 PendingReportUploadVerdictKind = string.Empty,
                 ReportUploadApiBaseUrl = DefaultReportUploadApiBaseUrl,
-                UploadedReportHashes = Array.Empty<string>()
+                UploadedReportHashes = Array.Empty<string>(),
+                IncludeMods = true,
+                IncludePlugins = true,
+                IncludeUserLibs = true,
+                IncludePatchers = true,
+                IncludeThunderstoreProfiles = true,
+                AdditionalTargetRoots = Array.Empty<string>(),
+                ExcludedTargetRoots = Array.Empty<string>()
             };
         }
 

--- a/BepInEx/BepInExConfigManager.cs
+++ b/BepInEx/BepInExConfigManager.cs
@@ -103,6 +103,7 @@ namespace MLVScan.BepInEx
                 EnableScanCache = true,
                 BlockKnownThreats = true,
                 BlockSuspicious = true,
+                BlockIncompleteScans = false,
                 MinSeverityForDisable = Severity.Medium,
                 ScanDirectories = new[] { "plugins" },
                 SuspiciousThreshold = 1,

--- a/BepInEx/BepInExConsentPlugin.cs
+++ b/BepInEx/BepInExConsentPlugin.cs
@@ -66,7 +66,7 @@ namespace MLVScan.BepInEx
             GUI.Box(new Rect(0f, 0f, Screen.width, Screen.height), string.Empty);
             GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
             GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
+                ConsentMessageHelper.GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
                 "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                 "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                 "No: do not upload and do not show this prompt again.");
@@ -158,16 +158,5 @@ namespace MLVScan.BepInEx
             };
         }
 
-        private static string GetUploadConsentMessage(string modName, string verdictKind)
-        {
-            var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
-            if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
-                string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
-            {
-                return $"MLVScan identified {label} as likely malware and disabled it.";
-            }
-
-            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
-        }
     }
 }

--- a/BepInEx/BepInExConsentPlugin.cs
+++ b/BepInEx/BepInExConsentPlugin.cs
@@ -19,6 +19,7 @@ namespace MLVScan.BepInEx
         private bool _showConsentPopup;
         private string _pendingUploadPath = string.Empty;
         private string _pendingUploadName = string.Empty;
+        private string _pendingUploadVerdictKind = string.Empty;
 
         private void Awake()
         {
@@ -39,6 +40,7 @@ namespace MLVScan.BepInEx
                     _pendingUploadName = string.IsNullOrWhiteSpace(_pendingUploadPath)
                         ? "flagged mod"
                         : Path.GetFileName(_pendingUploadPath);
+                    _pendingUploadVerdictKind = config.PendingReportUploadVerdictKind ?? string.Empty;
                     _showConsentPopup = true;
                     Logger.LogInfo("MLVScan upload consent popup is ready.");
                 }
@@ -64,7 +66,7 @@ namespace MLVScan.BepInEx
             GUI.Box(new Rect(0f, 0f, Screen.width, Screen.height), string.Empty);
             GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
             GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                $"MLVScan flagged {_pendingUploadName} as suspicious and disabled it.\n\n" +
+                GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
                 "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                 "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                 "No: do not upload and do not show this prompt again.");
@@ -93,6 +95,7 @@ namespace MLVScan.BepInEx
             config.ReportUploadConsentAsked = true;
             config.ReportUploadConsentPending = false;
             config.PendingReportUploadPath = string.Empty;
+            config.PendingReportUploadVerdictKind = string.Empty;
             config.EnableReportUpload = approved;
             _configManager.SaveConfig(config);
 
@@ -153,6 +156,18 @@ namespace MLVScan.BepInEx
                 ConsentVersion = "1",
                 ConsentTimestamp = DateTime.UtcNow.ToString("o")
             };
+        }
+
+        private static string GetUploadConsentMessage(string modName, string verdictKind)
+        {
+            var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
+            if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
+                string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
+            {
+                return $"MLVScan identified {label} as likely malware and disabled it.";
+            }
+
+            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
         }
     }
 }

--- a/BepInEx/BepInExIl2CppConsentPlugin.cs
+++ b/BepInEx/BepInExIl2CppConsentPlugin.cs
@@ -43,6 +43,7 @@ namespace MLVScan.BepInEx
             private readonly ReportUploadService _reportUploadService;
             private string _pendingUploadPath = string.Empty;
             private string _pendingUploadName = string.Empty;
+            private string _pendingUploadVerdictKind = string.Empty;
 
             public bool ShouldShowPopup { get; private set; }
 
@@ -86,6 +87,7 @@ namespace MLVScan.BepInEx
                 _pendingUploadName = string.IsNullOrWhiteSpace(_pendingUploadPath)
                     ? "flagged mod"
                     : Path.GetFileName(_pendingUploadPath);
+                _pendingUploadVerdictKind = config.PendingReportUploadVerdictKind ?? string.Empty;
             }
 
             public void DrawGui()
@@ -103,7 +105,7 @@ namespace MLVScan.BepInEx
                 GUI.Box(new Rect(0f, 0f, Screen.width, Screen.height), string.Empty);
                 GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
                 GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                    $"MLVScan flagged {_pendingUploadName} as suspicious and disabled it.\n\n" +
+                    GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
                     "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                     "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                     "No: do not upload and do not show this prompt again.");
@@ -127,6 +129,7 @@ namespace MLVScan.BepInEx
                 config.ReportUploadConsentAsked = true;
                 config.ReportUploadConsentPending = false;
                 config.PendingReportUploadPath = string.Empty;
+                config.PendingReportUploadVerdictKind = string.Empty;
                 config.EnableReportUpload = approved;
                 _configManager.SaveConfig(config);
 
@@ -179,6 +182,18 @@ namespace MLVScan.BepInEx
                 {
                     _logger.LogWarning($"MLVScan upload failed: {ex.Message}");
                 }
+            }
+
+            private static string GetUploadConsentMessage(string modName, string verdictKind)
+            {
+                var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
+                if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
+                    string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
+                {
+                    return $"MLVScan identified {label} as likely malware and disabled it.";
+                }
+
+                return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
             }
         }
     }

--- a/BepInEx/BepInExIl2CppConsentPlugin.cs
+++ b/BepInEx/BepInExIl2CppConsentPlugin.cs
@@ -105,7 +105,7 @@ namespace MLVScan.BepInEx
                 GUI.Box(new Rect(0f, 0f, Screen.width, Screen.height), string.Empty);
                 GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
                 GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                    GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
+                    ConsentMessageHelper.GetUploadConsentMessage(_pendingUploadName, _pendingUploadVerdictKind) + "\n\n" +
                     "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                     "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                     "No: do not upload and do not show this prompt again.");
@@ -182,18 +182,6 @@ namespace MLVScan.BepInEx
                 {
                     _logger.LogWarning($"MLVScan upload failed: {ex.Message}");
                 }
-            }
-
-            private static string GetUploadConsentMessage(string modName, string verdictKind)
-            {
-                var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
-                if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
-                    string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
-                {
-                    return $"MLVScan identified {label} as likely malware and disabled it.";
-                }
-
-                return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
             }
         }
     }

--- a/BepInEx/BepInExPluginScanner.cs
+++ b/BepInEx/BepInExPluginScanner.cs
@@ -127,7 +127,7 @@ namespace MLVScan.BepInEx
             AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
             AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
 
-            foreach (var scanDir in Config.ScanDirectories)
+            foreach (var scanDir in Config.ScanDirectories ?? Array.Empty<string>())
             {
                 AddIfPresent(Path.IsPathRooted(scanDir)
                     ? scanDir

--- a/BepInEx/BepInExPluginScanner.cs
+++ b/BepInEx/BepInExPluginScanner.cs
@@ -32,6 +32,13 @@ namespace MLVScan.BepInEx
         protected override IEnumerable<string> GetScanDirectories()
         {
             var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var builtInRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                Path.GetFullPath(Paths.PluginPath),
+                Path.GetFullPath(Paths.PatcherPluginPath),
+                Path.GetFullPath(Path.Combine(_environment.GameRootDirectory, "UserLibs")),
+                Path.GetFullPath(Path.Combine(_environment.GameRootDirectory, "Mods"))
+            };
 
             if (Config.IncludePlugins)
             {
@@ -53,11 +60,9 @@ namespace MLVScan.BepInEx
                 AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
             }
 
-            foreach (var scanDir in Config.ScanDirectories)
+            foreach (var scanDir in Config.ScanDirectories ?? Array.Empty<string>())
             {
-                AddIfPresent(Path.IsPathRooted(scanDir)
-                    ? scanDir
-                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+                AddLegacyIfPresent(scanDir);
             }
 
             foreach (var path in emitted)
@@ -73,6 +78,25 @@ namespace MLVScan.BepInEx
                 }
 
                 emitted.Add(Path.GetFullPath(path));
+            }
+
+            void AddLegacyIfPresent(string scanDir)
+            {
+                if (string.IsNullOrWhiteSpace(scanDir))
+                {
+                    return;
+                }
+
+                var resolvedPath = Path.GetFullPath(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+
+                if (builtInRoots.Contains(resolvedPath))
+                {
+                    return;
+                }
+
+                AddIfPresent(resolvedPath);
             }
         }
 

--- a/BepInEx/BepInExPluginScanner.cs
+++ b/BepInEx/BepInExPluginScanner.cs
@@ -5,6 +5,7 @@ using BepInEx;
 using MLVScan.Abstractions;
 using MLVScan.Models;
 using MLVScan.Services;
+using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.BepInEx
 {
@@ -21,8 +22,9 @@ namespace MLVScan.BepInEx
             IAssemblyResolverProvider resolverProvider,
             MLVScanConfig config,
             IConfigManager configManager,
-            BepInExPlatformEnvironment environment)
-            : base(logger, resolverProvider, config, configManager, environment)
+            BepInExPlatformEnvironment environment,
+            LoaderScanTelemetryHub telemetry)
+            : base(logger, resolverProvider, config, configManager, environment, telemetry)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
@@ -89,6 +91,35 @@ namespace MLVScan.BepInEx
             catch
             {
                 return false;
+            }
+        }
+
+        protected override IEnumerable<string> GetResolverDirectories()
+        {
+            var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            AddIfPresent(Paths.PluginPath);
+            AddIfPresent(Paths.PatcherPluginPath);
+            AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
+            AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
+
+            foreach (var scanDir in Config.ScanDirectories)
+            {
+                AddIfPresent(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+            }
+
+            return emitted;
+
+            void AddIfPresent(string path)
+            {
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    return;
+                }
+
+                emitted.Add(Path.GetFullPath(path));
             }
         }
     }

--- a/BepInEx/BepInExPluginScanner.cs
+++ b/BepInEx/BepInExPluginScanner.cs
@@ -22,17 +22,55 @@ namespace MLVScan.BepInEx
             MLVScanConfig config,
             IConfigManager configManager,
             BepInExPlatformEnvironment environment)
-            : base(logger, resolverProvider, config, configManager)
+            : base(logger, resolverProvider, config, configManager, environment)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
         protected override IEnumerable<string> GetScanDirectories()
         {
-            // BepInEx plugins directory
-            if (Directory.Exists(Paths.PluginPath))
+            var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (Config.IncludePlugins)
             {
-                yield return Paths.PluginPath;
+                AddIfPresent(Paths.PluginPath);
+            }
+
+            if (Config.IncludePatchers)
+            {
+                AddIfPresent(Paths.PatcherPluginPath);
+            }
+
+            if (Config.IncludeUserLibs)
+            {
+                AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
+            }
+
+            if (Config.IncludeMods)
+            {
+                AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
+            }
+
+            foreach (var scanDir in Config.ScanDirectories)
+            {
+                AddIfPresent(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+            }
+
+            foreach (var path in emitted)
+            {
+                yield return path;
+            }
+
+            void AddIfPresent(string path)
+            {
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    return;
+                }
+
+                emitted.Add(Path.GetFullPath(path));
             }
         }
 

--- a/BepInEx/BepInExReportGenerator.cs
+++ b/BepInEx/BepInExReportGenerator.cs
@@ -112,17 +112,17 @@ namespace MLVScan.BepInEx
         {
             _logger.LogWarning("--- SECURITY NOTICE ---");
             _logger.LogInfo($"MLVScan blocked {pluginName} before it could execute.");
-            if (threatVerdict?.Kind == ThreatVerdictKind.KnownMaliciousSample ||
-                threatVerdict?.Kind == ThreatVerdictKind.KnownMalwareFamily)
+            if (IsKnownThreatVerdict(threatVerdict))
             {
-                _logger.LogInfo("This block was reinforced by a match to previously analyzed malware.");
+                _logger.LogInfo("This plugin is likely malware because it matched previously analyzed malware intelligence.");
                 _logger.LogInfo("If this is your first time with this plugin, you are likely safe.");
                 _logger.LogInfo("If you've used it before, run a malware scan and review the report immediately.");
             }
             else
             {
-                _logger.LogInfo("This plugin was blocked as a precaution based on suspicious behavior patterns.");
+                _logger.LogInfo("This plugin was blocked because it triggered suspicious correlated behavior.");
                 _logger.LogInfo("It may still be a false positive, so use the saved report for human review before assuming infection.");
+                _logger.LogInfo("Review the detailed report before deciding whether to whitelist it.");
             }
             _logger.LogInfo("");
             _logger.LogInfo("To whitelist a false positive:");
@@ -266,9 +266,19 @@ namespace MLVScan.BepInEx
                 sb.AppendLine(new string('=', 60));
                 sb.AppendLine("SECURITY RECOMMENDATIONS");
                 sb.AppendLine(new string('=', 60));
-                sb.AppendLine("1. Verify with the modding community if this is a known mod");
-                sb.AppendLine("2. Run a full system scan with Malwarebytes or similar");
-                sb.AppendLine("3. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
+                if (IsKnownThreatVerdict(pluginInfo.ThreatVerdict))
+                {
+                    sb.AppendLine("1. Verify with the modding community if this is a known mod");
+                    sb.AppendLine("2. Run a full system scan with Malwarebytes or similar");
+                    sb.AppendLine("3. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
+                }
+                else
+                {
+                    sb.AppendLine("1. Verify with the modding community if this is a known mod");
+                    sb.AppendLine("2. Review the detailed report before assuming infection");
+                    sb.AppendLine("3. Only run a full system scan if you have already executed this plugin");
+                    sb.AppendLine("4. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
+                }
                 sb.AppendLine();
                 sb.AppendLine("To whitelist (if false positive):");
                 sb.AppendLine($"  Add this hash to BepInEx/config/MLVScan.json:");
@@ -339,6 +349,12 @@ namespace MLVScan.BepInEx
             {
                 _logger.LogError($"Failed to create report directory: {ex.Message}");
             }
+        }
+
+        private static bool IsKnownThreatVerdict(ThreatVerdictInfo threatVerdict)
+        {
+            return threatVerdict?.Kind == ThreatVerdictKind.KnownMaliciousSample ||
+                   threatVerdict?.Kind == ThreatVerdictKind.KnownMalwareFamily;
         }
     }
 }

--- a/BepInEx/BepInExReportGenerator.cs
+++ b/BepInEx/BepInExReportGenerator.cs
@@ -141,6 +141,7 @@ namespace MLVScan.BepInEx
             try
             {
                 var findings = scanResult?.Findings ?? new List<ScanFinding>();
+                var resolvedVerdict = pluginInfo?.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
                 var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
                 var reportPath = Path.Combine(_reportDirectory, $"{pluginName}_{timestamp}.report.txt");
 
@@ -158,7 +159,7 @@ namespace MLVScan.BepInEx
 
                 using (var verdictWriter = new StringWriter(sb))
                 {
-                    ThreatVerdictTextFormatter.WriteThreatVerdictSection(verdictWriter, pluginInfo.ThreatVerdict ?? scanResult?.ThreatVerdict);
+                    ThreatVerdictTextFormatter.WriteThreatVerdictSection(verdictWriter, resolvedVerdict);
                 }
 
                 // Severity breakdown
@@ -266,7 +267,7 @@ namespace MLVScan.BepInEx
                 sb.AppendLine(new string('=', 60));
                 sb.AppendLine("SECURITY RECOMMENDATIONS");
                 sb.AppendLine(new string('=', 60));
-                if (IsKnownThreatVerdict(pluginInfo.ThreatVerdict))
+                if (IsKnownThreatVerdict(resolvedVerdict))
                 {
                     sb.AppendLine("1. Verify with the modding community if this is a known mod");
                     sb.AppendLine("2. Run a full system scan with Malwarebytes or similar");

--- a/BepInEx/BepInExReportGenerator.cs
+++ b/BepInEx/BepInExReportGenerator.cs
@@ -12,7 +12,7 @@ using MLVScan.Services;
 namespace MLVScan.BepInEx
 {
     /// <summary>
-    /// Generates detailed reports for blocked plugins.
+    /// Generates detailed reports for blocked plugins and review-required plugins.
     /// </summary>
     public class BepInExReportGenerator
     {
@@ -44,12 +44,13 @@ namespace MLVScan.BepInEx
         {
             EnsureReportDirectoryExists();
 
-            foreach (var pluginInfo in disabledPlugins)
-            {
-                if (!scanResults.TryGetValue(pluginInfo.OriginalPath, out var scanResult))
-                    continue;
+            var disabledByPath = (disabledPlugins ?? new List<DisabledPluginInfo>())
+                .ToDictionary(info => info.OriginalPath, StringComparer.OrdinalIgnoreCase);
 
-                var pluginName = Path.GetFileName(pluginInfo.OriginalPath);
+            foreach (var (pluginPath, scanResult) in scanResults.OrderBy(kv => Path.GetFileName(kv.Key), StringComparer.OrdinalIgnoreCase))
+            {
+                disabledByPath.TryGetValue(pluginPath, out var pluginInfo);
+                var pluginName = Path.GetFileName(pluginPath);
 
                 // Log to console
                 LogConsoleReport(pluginName, pluginInfo, scanResult);
@@ -63,12 +64,31 @@ namespace MLVScan.BepInEx
         {
             var findings = scanResult?.Findings ?? new List<ScanFinding>();
             var threatVerdict = pluginInfo?.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
+            var scanStatus = pluginInfo?.ScanStatus ?? scanResult?.ScanStatus ?? new ScanStatusInfo();
+            var wasBlocked = pluginInfo != null;
+            var outcomeLabel = ThreatVerdictTextFormatter.GetOutcomeLabel(scanResult);
+            var outcomeSummary = ThreatVerdictTextFormatter.GetOutcomeSummary(scanResult);
+            var fileHash = pluginInfo?.FileHash ?? scanResult?.FileHash ?? string.Empty;
 
             _logger.LogWarning(new string('=', 50));
-            _logger.LogWarning($"BLOCKED PLUGIN: {pluginName}");
-            _logger.LogInfo($"SHA256: {pluginInfo.FileHash}");
-            _logger.LogWarning($"Verdict: {ThreatVerdictTextFormatter.GetVerdictLabel(threatVerdict)}");
-            _logger.LogInfo(threatVerdict.Summary);
+            _logger.LogWarning($"{(wasBlocked ? "BLOCKED PLUGIN" : "REVIEW REQUIRED")}: {pluginName}");
+            _logger.LogInfo($"SHA256: {fileHash}");
+            if (!string.IsNullOrWhiteSpace(outcomeLabel))
+            {
+                _logger.LogWarning($"Outcome: {outcomeLabel}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(outcomeSummary))
+            {
+                _logger.LogInfo(outcomeSummary);
+            }
+
+            if (scanStatus.Kind != ScanStatusKind.Complete)
+            {
+                _logger.LogInfo(wasBlocked
+                    ? "Action: blocked by current incomplete-scan policy."
+                    : "Action: manual review required; not blocked by current config.");
+            }
 
             var familyName = ThreatVerdictTextFormatter.GetPrimaryFamilyLabel(threatVerdict);
             if (!string.IsNullOrWhiteSpace(familyName))
@@ -82,7 +102,7 @@ namespace MLVScan.BepInEx
                 _logger.LogInfo($"Confidence: {confidenceLabel}");
             }
 
-            _logger.LogInfo($"Suspicious patterns: {findings.Count}");
+            _logger.LogInfo($"Retained findings: {findings.Count}");
 
             var grouped = findings
                 .GroupBy(f => f.Severity)
@@ -105,23 +125,39 @@ namespace MLVScan.BepInEx
 
             _logger.LogInfo("Full technical details were written to the saved report file for human review.");
 
-            DisplaySecurityNotice(pluginName, threatVerdict);
+            DisplaySecurityNotice(pluginName, threatVerdict, scanStatus, wasBlocked);
         }
 
-        private void DisplaySecurityNotice(string pluginName, ThreatVerdictInfo threatVerdict)
+        private void DisplaySecurityNotice(
+            string pluginName,
+            ThreatVerdictInfo threatVerdict,
+            ScanStatusInfo scanStatus,
+            bool wasBlocked)
         {
             _logger.LogWarning("--- SECURITY NOTICE ---");
-            _logger.LogInfo($"MLVScan blocked {pluginName} before it could execute.");
+            _logger.LogInfo(wasBlocked
+                ? $"MLVScan blocked {pluginName} before it could execute."
+                : $"MLVScan flagged {pluginName} for review but did not block it under the current configuration.");
             if (IsKnownThreatVerdict(threatVerdict))
             {
                 _logger.LogInfo("This plugin is likely malware because it matched previously analyzed malware intelligence.");
                 _logger.LogInfo("If this is your first time with this plugin, you are likely safe.");
                 _logger.LogInfo("If you've used it before, run a malware scan and review the report immediately.");
             }
+            else if (threatVerdict?.Kind == ThreatVerdictKind.Suspicious)
+            {
+                _logger.LogInfo("This plugin was flagged because it triggered suspicious correlated behavior.");
+                _logger.LogInfo("It may still be a false positive, so use the saved report for human review before assuming infection.");
+                _logger.LogInfo("Review the detailed report before deciding whether to whitelist it.");
+            }
+            else if (scanStatus?.Kind == ScanStatusKind.RequiresReview)
+            {
+                _logger.LogInfo("This plugin could not be fully analyzed by the loader because it exceeded the current in-memory scan limit.");
+                _logger.LogInfo("MLVScan still calculated its SHA-256 hash and checked exact known-malicious sample matches.");
+                _logger.LogInfo("Review the detailed report before deciding whether to whitelist it or enable strict incomplete-scan blocking.");
+            }
             else
             {
-                _logger.LogInfo("This plugin was blocked because it triggered suspicious correlated behavior.");
-                _logger.LogInfo("It may still be a false positive, so use the saved report for human review before assuming infection.");
                 _logger.LogInfo("Review the detailed report before deciding whether to whitelist it.");
             }
             _logger.LogInfo("");
@@ -142,6 +178,13 @@ namespace MLVScan.BepInEx
             {
                 var findings = scanResult?.Findings ?? new List<ScanFinding>();
                 var resolvedVerdict = pluginInfo?.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
+                var resolvedScanStatus = pluginInfo?.ScanStatus ?? scanResult?.ScanStatus ?? new ScanStatusInfo();
+                var wasBlocked = pluginInfo != null;
+                var originalPath = pluginInfo?.OriginalPath ?? scanResult?.FilePath ?? string.Empty;
+                var currentPath = pluginInfo?.DisabledPath ?? scanResult?.FilePath ?? string.Empty;
+                var fileHash = pluginInfo?.FileHash ?? scanResult?.FileHash ?? string.Empty;
+                var outcomeLabel = ThreatVerdictTextFormatter.GetOutcomeLabel(scanResult);
+                var outcomeSummary = ThreatVerdictTextFormatter.GetOutcomeSummary(scanResult);
                 var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
                 var reportPath = Path.Combine(_reportDirectory, $"{pluginName}_{timestamp}.report.txt");
 
@@ -151,15 +194,22 @@ namespace MLVScan.BepInEx
                 sb.AppendLine(new string('=', 60));
                 sb.AppendLine($"Generated: {DateTime.Now}");
                 sb.AppendLine($"Plugin: {pluginName}");
-                sb.AppendLine($"SHA256: {pluginInfo.FileHash}");
-                sb.AppendLine($"Original Path: {pluginInfo.OriginalPath}");
-                sb.AppendLine($"Blocked Path: {pluginInfo.DisabledPath}");
+                sb.AppendLine($"Outcome: {outcomeLabel}");
+                if (!string.IsNullOrWhiteSpace(outcomeSummary))
+                {
+                    sb.AppendLine($"Outcome Summary: {outcomeSummary}");
+                }
+                sb.AppendLine($"Action Taken: {(wasBlocked ? "Blocked" : "Manual review required (not blocked by current config)")}");
+                sb.AppendLine($"SHA256: {fileHash}");
+                sb.AppendLine($"Original Path: {originalPath}");
+                sb.AppendLine($"{(wasBlocked ? "Blocked Path" : "Current Path")}: {currentPath}");
                 sb.AppendLine($"Total Findings: {findings.Count}");
                 sb.AppendLine();
 
                 using (var verdictWriter = new StringWriter(sb))
                 {
                     ThreatVerdictTextFormatter.WriteThreatVerdictSection(verdictWriter, resolvedVerdict);
+                    ThreatVerdictTextFormatter.WriteScanStatusSection(verdictWriter, resolvedScanStatus);
                 }
 
                 // Severity breakdown
@@ -273,6 +323,20 @@ namespace MLVScan.BepInEx
                     sb.AppendLine("2. Run a full system scan with Malwarebytes or similar");
                     sb.AppendLine("3. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
                 }
+                else if (resolvedVerdict?.Kind == ThreatVerdictKind.Suspicious)
+                {
+                    sb.AppendLine("1. Verify with the modding community if this is a known mod");
+                    sb.AppendLine("2. Review the detailed report before assuming infection");
+                    sb.AppendLine("3. Only run a full system scan if you have already executed this plugin");
+                    sb.AppendLine("4. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
+                }
+                else if (resolvedScanStatus?.Kind == ScanStatusKind.RequiresReview)
+                {
+                    sb.AppendLine("1. Review the detailed report before assuming the plugin is safe");
+                    sb.AppendLine("2. Validate the plugin with the original author or trusted community sources");
+                    sb.AppendLine("3. Enable BlockIncompleteScans if you want oversized or incomplete scans blocked automatically");
+                    sb.AppendLine("4. Check the Discord for guidance: https://discord.gg/UD4K4chKak");
+                }
                 else
                 {
                     sb.AppendLine("1. Verify with the modding community if this is a known mod");
@@ -283,16 +347,20 @@ namespace MLVScan.BepInEx
                 sb.AppendLine();
                 sb.AppendLine("To whitelist (if false positive):");
                 sb.AppendLine($"  Add this hash to BepInEx/config/MLVScan.json:");
-                sb.AppendLine($"  \"{pluginInfo.FileHash}\"");
+                sb.AppendLine($"  \"{fileHash}\"");
 
                 File.WriteAllText(reportPath, sb.ToString());
                 _logger.LogInfo($"Report saved: {reportPath}");
 
-                if (_config.EnableReportUpload && !string.IsNullOrWhiteSpace(_reportUploadApiBaseUrl))
+                if (_config.EnableReportUpload &&
+                    !string.IsNullOrWhiteSpace(_reportUploadApiBaseUrl) &&
+                    resolvedVerdict.Kind != ThreatVerdictKind.None)
                 {
                     try
                     {
-                        var accessiblePath = File.Exists(pluginInfo.DisabledPath) ? pluginInfo.DisabledPath : pluginInfo.OriginalPath;
+                        var accessiblePath = pluginInfo != null && File.Exists(pluginInfo.DisabledPath)
+                            ? pluginInfo.DisabledPath
+                            : (scanResult?.FilePath ?? string.Empty);
                         if (File.Exists(accessiblePath))
                         {
                             var assemblyBytes = File.ReadAllBytes(accessiblePath);

--- a/BepInEx/ConsentMessageHelper.cs
+++ b/BepInEx/ConsentMessageHelper.cs
@@ -1,0 +1,20 @@
+using System;
+using MLVScan.Models;
+
+namespace MLVScan.BepInEx
+{
+    internal static class ConsentMessageHelper
+    {
+        public static string GetUploadConsentMessage(string modName, string verdictKind)
+        {
+            var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
+            if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
+                string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
+            {
+                return $"MLVScan identified {label} as likely malware and disabled it.";
+            }
+
+            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
+        }
+    }
+}

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Services\Caching\IScanCacheSigner.cs" />
     <Compile Include="Services\Caching\IScanCacheStore.cs" />
     <Compile Include="Services\Caching\RuntimeInformationHelper.cs" />
+    <Compile Include="Services\Caching\ScanCacheEnvelopeCodec.cs" />
     <Compile Include="Services\Caching\ScanCacheModels.cs" />
     <Compile Include="Services\Caching\ScanCacheSigner.cs" />
     <Compile Include="Services\Caching\SecureScanCacheStore.cs" />
@@ -277,9 +278,7 @@
                        Condition="'$(UseLocalMLVScanCore)' == 'true'" />
 
     <PackageReference Include="ILRepack" Version="2.0.44" GeneratePathProperty="true" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Abstractions\IConfigManager.cs" />
     <Compile Include="Abstractions\IPlatformEnvironment.cs" />
     <Compile Include="Models\MLVScanConfig.cs" />
+    <Compile Include="BepInEx\ConsentMessageHelper.cs" />
     <Compile Include="Services\PluginScannerBase.cs" />
     <Compile Include="Services\Caching\AtomicFileStorage.cs" />
     <Compile Include="Services\Caching\CrossPlatformFileIdentityProvider.cs" />

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -258,11 +258,19 @@
     <PackageReference Include="BepInEx.Core" Version="6.0.0-be.*" IncludeAssets="compile" GeneratePathProperty="true" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" GeneratePathProperty="true" />
     <PackageReference Include="BepInEx.Preloader.Core" Version="6.0.0-be.*" IncludeAssets="compile" GeneratePathProperty="true" />
-    <PackageReference Include="UnityEngine" Version="5.6.1" />
+    <!-- IL2CPP games expose Unity types from module assemblies, not the legacy monolithic UnityEngine.dll. -->
     <PackageReference Include="UnityEngine.CoreModule" Version="2020.3.0" />
     <PackageReference Include="UnityEngine.IMGUIModule" Version="2020.3.0" />
     <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(NuGetPackageRoot)unityengine.coremodule\2020.3.0\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule">
+      <HintPath>$(NuGetPackageRoot)unityengine.imguimodule\2020.3.0\UnityEngine.IMGUIModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <!-- ============================================ -->

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -96,7 +96,7 @@
     <Compile Include="Abstractions\IConfigManager.cs" />
     <Compile Include="Abstractions\IPlatformEnvironment.cs" />
     <Compile Include="Models\MLVScanConfig.cs" />
-    <Compile Include="BepInEx\ConsentMessageHelper.cs" />
+    <Compile Include="Services\ConsentMessageHelper.cs" />
     <Compile Include="Services\PluginScannerBase.cs" />
     <Compile Include="Services\Caching\AtomicFileStorage.cs" />
     <Compile Include="Services\Caching\CrossPlatformFileIdentityProvider.cs" />

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -10,6 +10,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <EnableMlvScanProfiling>false</EnableMlvScanProfiling>
     <RootNamespace>MLVScan</RootNamespace>
     <IsPackable>false</IsPackable>
     <Version>1.6.6</Version>
@@ -18,8 +19,13 @@
     <InformationalVersion>$(Version)</InformationalVersion>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Configurations>MelonLoader;BepInEx5;BepInEx6Mono;BepInEx6IL2CPP</Configurations>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(EnableMlvScanProfiling)' == 'true'">
+    <DefineConstants>$(DefineConstants);MLVSCAN_PROFILING</DefineConstants>
   </PropertyGroup>
 
   <!-- ============================================ -->
@@ -91,6 +97,21 @@
     <Compile Include="Abstractions\IPlatformEnvironment.cs" />
     <Compile Include="Models\MLVScanConfig.cs" />
     <Compile Include="Services\PluginScannerBase.cs" />
+    <Compile Include="Services\Caching\AtomicFileStorage.cs" />
+    <Compile Include="Services\Caching\CrossPlatformFileIdentityProvider.cs" />
+    <Compile Include="Services\Caching\IFileIdentityProvider.cs" />
+    <Compile Include="Services\Caching\IScanCacheSigner.cs" />
+    <Compile Include="Services\Caching\IScanCacheStore.cs" />
+    <Compile Include="Services\Caching\RuntimeInformationHelper.cs" />
+    <Compile Include="Services\Caching\ScanCacheModels.cs" />
+    <Compile Include="Services\Caching\ScanCacheSigner.cs" />
+    <Compile Include="Services\Caching\SecureScanCacheStore.cs" />
+    <Compile Include="Services\Diagnostics\LoaderScanTelemetryHub.cs" />
+    <Compile Include="Services\Resolution\AssemblyResolverCatalogBuilder.cs" />
+    <Compile Include="Services\Resolution\CatalogingAssemblyResolverProviderBase.cs" />
+    <Compile Include="Services\Resolution\IResolverCatalogProvider.cs" />
+    <Compile Include="Services\Resolution\IndexedAssemblyResolver.cs" />
+    <Compile Include="Services\Resolution\ResolverCatalogModels.cs" />
     <Compile Include="Services\Scope\TargetAssemblyScopeFilter.cs" />
     <Compile Include="Services\PluginDisablerBase.cs" />
     <Compile Include="Services\DeveloperReportGenerator.cs" />
@@ -255,7 +276,9 @@
                        Condition="'$(UseLocalMLVScanCore)' == 'true'" />
 
     <PackageReference Include="ILRepack" Version="2.0.44" GeneratePathProperty="true" />
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Mono.Cecil" Version="0.11.6" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="9.0.6" />
     <PackageReference Include="System.Text.Json" Version="6.0.11" />
   </ItemGroup>
 

--- a/MLVScan.csproj
+++ b/MLVScan.csproj
@@ -42,7 +42,7 @@
   <!-- MelonLoader Configuration                   -->
   <!-- ============================================ -->
   <PropertyGroup Condition="'$(Configuration)'=='MelonLoader'">
-    <DefineConstants>MELONLOADER</DefineConstants>
+    <DefineConstants>$(DefineConstants);MELONLOADER</DefineConstants>
     <AssemblyName>MLVScan.MelonLoader</AssemblyName>
     <NoWarn>$(NoWarn);MSB3277</NoWarn>
   </PropertyGroup>
@@ -51,7 +51,7 @@
   <!-- BepInEx 5.x Configuration                   -->
   <!-- ============================================ -->
   <PropertyGroup Condition="'$(Configuration)'=='BepInEx5'">
-    <DefineConstants>BEPINEX</DefineConstants>
+    <DefineConstants>$(DefineConstants);BEPINEX</DefineConstants>
     <AssemblyName>MLVScan.BepInEx5</AssemblyName>
   </PropertyGroup>
 
@@ -59,7 +59,7 @@
   <!-- BepInEx 6.x Mono Configuration              -->
   <!-- ============================================ -->
   <PropertyGroup Condition="'$(Configuration)'=='BepInEx6Mono'">
-    <DefineConstants>BEPINEX;BEPINEX6;BEPINEX6_MONO</DefineConstants>
+    <DefineConstants>$(DefineConstants);BEPINEX;BEPINEX6;BEPINEX6_MONO</DefineConstants>
     <AssemblyName>MLVScan.BepInEx6.Mono</AssemblyName>
   </PropertyGroup>
 
@@ -68,7 +68,7 @@
   <!-- ============================================ -->
   <PropertyGroup Condition="'$(Configuration)'=='BepInEx6IL2CPP'">
     <TargetFramework>net6.0</TargetFramework>
-    <DefineConstants>BEPINEX;BEPINEX6;BEPINEX6_IL2CPP</DefineConstants>
+    <DefineConstants>$(DefineConstants);BEPINEX;BEPINEX6;BEPINEX6_IL2CPP</DefineConstants>
     <AssemblyName>MLVScan.BepInEx6.IL2CPP</AssemblyName>
   </PropertyGroup>
 

--- a/MelonLoader/Adapters/GameAssemblyResolverProvider.cs
+++ b/MelonLoader/Adapters/GameAssemblyResolverProvider.cs
@@ -13,8 +13,8 @@ namespace MLVScan.Adapters
     /// </summary>
     public class GameAssemblyResolverProvider : CatalogingAssemblyResolverProviderBase
     {
-        public GameAssemblyResolverProvider()
-            : base()
+        public GameAssemblyResolverProvider(LoaderScanTelemetryHub telemetry)
+            : base(telemetry)
         {
         }
 

--- a/MelonLoader/Adapters/GameAssemblyResolverProvider.cs
+++ b/MelonLoader/Adapters/GameAssemblyResolverProvider.cs
@@ -1,6 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
 using MelonLoader.Utils;
-using MLVScan.Abstractions;
-using Mono.Cecil;
+using MLVScan.Services.Diagnostics;
+using MLVScan.Services.Resolution;
 
 namespace MLVScan.Adapters
 {
@@ -8,57 +11,53 @@ namespace MLVScan.Adapters
     /// Provides assembly resolution for game assemblies in MelonLoader context.
     /// Adds the game's Managed folder and MelonLoader folder to the search paths.
     /// </summary>
-    public class GameAssemblyResolverProvider : IAssemblyResolverProvider
+    public class GameAssemblyResolverProvider : CatalogingAssemblyResolverProviderBase
     {
-        public IAssemblyResolver CreateResolver()
+        public GameAssemblyResolverProvider()
+            : base()
         {
-            var resolver = new DefaultAssemblyResolver();
+        }
+
+        protected override IEnumerable<ResolverRoot> GetStableRoots()
+        {
+            var roots = new List<ResolverRoot>();
 
             try
             {
-                // Add the game's Managed folder (contains Unity assemblies)
                 var managedPath = Path.Combine(
                     MelonEnvironment.GameRootDirectory,
                     $"{Path.GetFileNameWithoutExtension(MelonEnvironment.GameExecutablePath)}_Data",
                     "Managed");
 
                 if (Directory.Exists(managedPath))
-                    resolver.AddSearchDirectory(managedPath);
+                {
+                    roots.Add(new ResolverRoot(managedPath, 0));
+                }
 
-                // Add MelonLoader's assembly folder
-                var melonLoaderPath = Path.Combine(
+                var melonLoaderNet35Path = Path.Combine(
                     MelonEnvironment.GameRootDirectory,
                     "MelonLoader",
                     "net35");
+                if (Directory.Exists(melonLoaderNet35Path))
+                {
+                    roots.Add(new ResolverRoot(melonLoaderNet35Path, 5));
+                }
 
-                if (Directory.Exists(melonLoaderPath))
-                    resolver.AddSearchDirectory(melonLoaderPath);
-
-                // Also check for net6 folder (for newer MelonLoader versions)
                 var melonLoaderNet6Path = Path.Combine(
                     MelonEnvironment.GameRootDirectory,
                     "MelonLoader",
                     "net6");
-
                 if (Directory.Exists(melonLoaderNet6Path))
-                    resolver.AddSearchDirectory(melonLoaderNet6Path);
-
-                // Add Mods directory (for mod-to-mod references)
-                var modsPath = MelonEnvironment.ModsDirectory;
-                if (Directory.Exists(modsPath))
-                    resolver.AddSearchDirectory(modsPath);
-
-                // Add Plugins directory (for plugin-to-plugin references)
-                var pluginsPath = MelonEnvironment.PluginsDirectory;
-                if (Directory.Exists(pluginsPath))
-                    resolver.AddSearchDirectory(pluginsPath);
+                {
+                    roots.Add(new ResolverRoot(melonLoaderNet6Path, 6));
+                }
             }
             catch (Exception)
             {
-                // If we can't set up the resolver, just use the default
+                return roots;
             }
 
-            return resolver;
+            return roots;
         }
     }
 }

--- a/MelonLoader/MelonConfigManager.cs
+++ b/MelonLoader/MelonConfigManager.cs
@@ -35,7 +35,6 @@ namespace MLVScan.MelonLoader
         private readonly MelonPreferences_Entry<bool> _includeMods;
         private readonly MelonPreferences_Entry<bool> _includePlugins;
         private readonly MelonPreferences_Entry<bool> _includeUserLibs;
-        private readonly MelonPreferences_Entry<bool> _includePatchers;
         private readonly MelonPreferences_Entry<bool> _includeThunderstoreProfiles;
         private readonly MelonPreferences_Entry<string[]> _additionalTargetRoots;
         private readonly MelonPreferences_Entry<string[]> _excludedTargetRoots;
@@ -111,9 +110,6 @@ namespace MLVScan.MelonLoader
                 _includeUserLibs = _category.CreateEntry("IncludeUserLibs", true,
                     description: "Whether to include UserLibs folders in the target scan scope");
 
-                _includePatchers = _category.CreateEntry("IncludePatchers", true,
-                    description: "Whether to include patcher folders in the target scan scope");
-
                 _includeThunderstoreProfiles = _category.CreateEntry("IncludeThunderstoreProfiles", true,
                     description: "Whether to include Thunderstore profile folders in the target scan scope");
 
@@ -144,7 +140,6 @@ namespace MLVScan.MelonLoader
                 _includeMods.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _includePlugins.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _includeUserLibs.OnEntryValueChanged.Subscribe(OnConfigChanged);
-                _includePatchers.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _includeThunderstoreProfiles.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _additionalTargetRoots.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _excludedTargetRoots.OnEntryValueChanged.Subscribe(OnConfigChanged);
@@ -203,7 +198,7 @@ namespace MLVScan.MelonLoader
                 IncludeMods = _includeMods.Value,
                 IncludePlugins = _includePlugins.Value,
                 IncludeUserLibs = _includeUserLibs.Value,
-                IncludePatchers = _includePatchers.Value,
+                IncludePatchers = false,
                 IncludeThunderstoreProfiles = _includeThunderstoreProfiles.Value,
                 AdditionalTargetRoots = _additionalTargetRoots.Value ?? Array.Empty<string>(),
                 ExcludedTargetRoots = _excludedTargetRoots.Value ?? Array.Empty<string>()
@@ -235,7 +230,6 @@ namespace MLVScan.MelonLoader
                 _includeMods.Value = newConfig.IncludeMods;
                 _includePlugins.Value = newConfig.IncludePlugins;
                 _includeUserLibs.Value = newConfig.IncludeUserLibs;
-                _includePatchers.Value = newConfig.IncludePatchers;
                 _includeThunderstoreProfiles.Value = newConfig.IncludeThunderstoreProfiles;
                 _additionalTargetRoots.Value = newConfig.AdditionalTargetRoots ?? Array.Empty<string>();
                 _excludedTargetRoots.Value = newConfig.ExcludedTargetRoots ?? Array.Empty<string>();

--- a/MelonLoader/MelonConfigManager.cs
+++ b/MelonLoader/MelonConfigManager.cs
@@ -16,6 +16,7 @@ namespace MLVScan.MelonLoader
 
         private readonly MelonPreferences_Entry<bool> _enableAutoScan;
         private readonly MelonPreferences_Entry<bool> _enableAutoDisable;
+        private readonly MelonPreferences_Entry<bool> _enableScanCache;
         private readonly MelonPreferences_Entry<bool> _blockKnownThreats;
         private readonly MelonPreferences_Entry<bool> _blockSuspicious;
         private readonly MelonPreferences_Entry<string> _minSeverityForDisable;
@@ -31,6 +32,13 @@ namespace MLVScan.MelonLoader
         private readonly MelonPreferences_Entry<string> _pendingReportUploadVerdictKind;
         private readonly MelonPreferences_Entry<string> _reportUploadApiBaseUrl;
         private readonly MelonPreferences_Entry<string[]> _uploadedReportHashes;
+        private readonly MelonPreferences_Entry<bool> _includeMods;
+        private readonly MelonPreferences_Entry<bool> _includePlugins;
+        private readonly MelonPreferences_Entry<bool> _includeUserLibs;
+        private readonly MelonPreferences_Entry<bool> _includePatchers;
+        private readonly MelonPreferences_Entry<bool> _includeThunderstoreProfiles;
+        private readonly MelonPreferences_Entry<string[]> _additionalTargetRoots;
+        private readonly MelonPreferences_Entry<string[]> _excludedTargetRoots;
 
         public MelonConfigManager(MelonLogger.Instance logger)
         {
@@ -45,6 +53,9 @@ namespace MLVScan.MelonLoader
 
                 _enableAutoDisable = _category.CreateEntry("EnableAutoDisable", true,
                     description: "Whether to disable suspicious mods");
+
+                _enableScanCache = _category.CreateEntry("EnableScanCache", true,
+                    description: "Whether to reuse scan results for unchanged files using a local authenticated cache");
 
                 _blockKnownThreats = _category.CreateEntry("BlockKnownThreats", true,
                     description: "Whether to block mods that match a known threat family or exact malicious sample");
@@ -91,8 +102,30 @@ namespace MLVScan.MelonLoader
                 _uploadedReportHashes = _category.CreateEntry("UploadedReportHashes", Array.Empty<string>(),
                     description: "List of assembly SHA256 hashes already uploaded to the MLVScan API (internal)");
 
+                _includeMods = _category.CreateEntry("IncludeMods", true,
+                    description: "Whether to include Mods folders in the target scan scope");
+
+                _includePlugins = _category.CreateEntry("IncludePlugins", true,
+                    description: "Whether to include Plugins folders in the target scan scope");
+
+                _includeUserLibs = _category.CreateEntry("IncludeUserLibs", true,
+                    description: "Whether to include UserLibs folders in the target scan scope");
+
+                _includePatchers = _category.CreateEntry("IncludePatchers", true,
+                    description: "Whether to include patcher folders in the target scan scope");
+
+                _includeThunderstoreProfiles = _category.CreateEntry("IncludeThunderstoreProfiles", true,
+                    description: "Whether to include Thunderstore profile folders in the target scan scope");
+
+                _additionalTargetRoots = _category.CreateEntry("AdditionalTargetRoots", Array.Empty<string>(),
+                    description: "Additional absolute paths to include in the target scan scope");
+
+                _excludedTargetRoots = _category.CreateEntry("ExcludedTargetRoots", Array.Empty<string>(),
+                    description: "Absolute paths to exclude from the target scan scope");
+
                 _enableAutoScan.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _enableAutoDisable.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _enableScanCache.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _blockKnownThreats.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _blockSuspicious.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _minSeverityForDisable.OnEntryValueChanged.Subscribe(OnConfigChanged);
@@ -108,6 +141,13 @@ namespace MLVScan.MelonLoader
                 _pendingReportUploadVerdictKind.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _reportUploadApiBaseUrl.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _uploadedReportHashes.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _includeMods.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _includePlugins.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _includeUserLibs.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _includePatchers.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _includeThunderstoreProfiles.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _additionalTargetRoots.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _excludedTargetRoots.OnEntryValueChanged.Subscribe(OnConfigChanged);
 
                 UpdateConfigFromPreferences();
 
@@ -141,6 +181,7 @@ namespace MLVScan.MelonLoader
             {
                 EnableAutoScan = _enableAutoScan.Value,
                 EnableAutoDisable = _enableAutoDisable.Value,
+                EnableScanCache = _enableScanCache.Value,
                 BlockKnownThreats = _blockKnownThreats.Value,
                 BlockSuspicious = _blockSuspicious.Value,
                 MinSeverityForDisable = ParseSeverity(_minSeverityForDisable.Value),
@@ -158,7 +199,14 @@ namespace MLVScan.MelonLoader
                 PendingReportUploadPath = _pendingReportUploadPath.Value,
                 PendingReportUploadVerdictKind = _pendingReportUploadVerdictKind.Value,
                 ReportUploadApiBaseUrl = _reportUploadApiBaseUrl.Value,
-                UploadedReportHashes = NormalizeHashes(_uploadedReportHashes.Value)
+                UploadedReportHashes = NormalizeHashes(_uploadedReportHashes.Value),
+                IncludeMods = _includeMods.Value,
+                IncludePlugins = _includePlugins.Value,
+                IncludeUserLibs = _includeUserLibs.Value,
+                IncludePatchers = _includePatchers.Value,
+                IncludeThunderstoreProfiles = _includeThunderstoreProfiles.Value,
+                AdditionalTargetRoots = _additionalTargetRoots.Value ?? Array.Empty<string>(),
+                ExcludedTargetRoots = _excludedTargetRoots.Value ?? Array.Empty<string>()
             };
         }
 
@@ -168,6 +216,7 @@ namespace MLVScan.MelonLoader
             {
                 _enableAutoScan.Value = newConfig.EnableAutoScan;
                 _enableAutoDisable.Value = newConfig.EnableAutoDisable;
+                _enableScanCache.Value = newConfig.EnableScanCache;
                 _blockKnownThreats.Value = newConfig.BlockKnownThreats;
                 _blockSuspicious.Value = newConfig.BlockSuspicious;
                 _minSeverityForDisable.Value = FormatSeverity(newConfig.MinSeverityForDisable);
@@ -183,6 +232,13 @@ namespace MLVScan.MelonLoader
                 _pendingReportUploadVerdictKind.Value = newConfig.PendingReportUploadVerdictKind ?? string.Empty;
                 _reportUploadApiBaseUrl.Value = newConfig.ReportUploadApiBaseUrl;
                 _uploadedReportHashes.Value = NormalizeHashes(newConfig.UploadedReportHashes);
+                _includeMods.Value = newConfig.IncludeMods;
+                _includePlugins.Value = newConfig.IncludePlugins;
+                _includeUserLibs.Value = newConfig.IncludeUserLibs;
+                _includePatchers.Value = newConfig.IncludePatchers;
+                _includeThunderstoreProfiles.Value = newConfig.IncludeThunderstoreProfiles;
+                _additionalTargetRoots.Value = newConfig.AdditionalTargetRoots ?? Array.Empty<string>();
+                _excludedTargetRoots.Value = newConfig.ExcludedTargetRoots ?? Array.Empty<string>();
 
                 MelonPreferences.Save();
 

--- a/MelonLoader/MelonConfigManager.cs
+++ b/MelonLoader/MelonConfigManager.cs
@@ -16,6 +16,8 @@ namespace MLVScan.MelonLoader
 
         private readonly MelonPreferences_Entry<bool> _enableAutoScan;
         private readonly MelonPreferences_Entry<bool> _enableAutoDisable;
+        private readonly MelonPreferences_Entry<bool> _blockKnownThreats;
+        private readonly MelonPreferences_Entry<bool> _blockSuspicious;
         private readonly MelonPreferences_Entry<string> _minSeverityForDisable;
         private readonly MelonPreferences_Entry<string[]> _scanDirectories;
         private readonly MelonPreferences_Entry<int> _suspiciousThreshold;
@@ -26,6 +28,7 @@ namespace MLVScan.MelonLoader
         private readonly MelonPreferences_Entry<bool> _reportUploadConsentAsked;
         private readonly MelonPreferences_Entry<bool> _reportUploadConsentPending;
         private readonly MelonPreferences_Entry<string> _pendingReportUploadPath;
+        private readonly MelonPreferences_Entry<string> _pendingReportUploadVerdictKind;
         private readonly MelonPreferences_Entry<string> _reportUploadApiBaseUrl;
         private readonly MelonPreferences_Entry<string[]> _uploadedReportHashes;
 
@@ -43,14 +46,20 @@ namespace MLVScan.MelonLoader
                 _enableAutoDisable = _category.CreateEntry("EnableAutoDisable", true,
                     description: "Whether to disable suspicious mods");
 
+                _blockKnownThreats = _category.CreateEntry("BlockKnownThreats", true,
+                    description: "Whether to block mods that match a known threat family or exact malicious sample");
+
+                _blockSuspicious = _category.CreateEntry("BlockSuspicious", true,
+                    description: "Whether to block suspicious unknown behavior that may still be a false positive");
+
                 _minSeverityForDisable = _category.CreateEntry("MinSeverityForDisable", "Medium",
-                    description: "Minimum severity level to trigger disabling (Low, Medium, High, Critical)");
+                    description: "Legacy setting from the old severity-based blocking model (no longer used for blocking)");
 
                 _scanDirectories = _category.CreateEntry("ScanDirectories", new[] { "Mods", "Plugins" },
                     description: "Directories to scan for mods");
 
                 _suspiciousThreshold = _category.CreateEntry("SuspiciousThreshold", 1,
-                    description: "How many suspicious findings required before disabling a mod");
+                    description: "Legacy setting from the old threshold-based blocking model (no longer used for blocking)");
 
                 _whitelistedHashes = _category.CreateEntry("WhitelistedHashes", Array.Empty<string>(),
                     description: "List of mod SHA256 hashes to skip when scanning");
@@ -73,6 +82,9 @@ namespace MLVScan.MelonLoader
                 _pendingReportUploadPath = _category.CreateEntry("PendingReportUploadPath", string.Empty,
                     description: "Suspicious mod path waiting for upload consent (internal)");
 
+                _pendingReportUploadVerdictKind = _category.CreateEntry("PendingReportUploadVerdictKind", string.Empty,
+                    description: "Threat verdict kind for the pending upload consent item (internal)");
+
                 _reportUploadApiBaseUrl = _category.CreateEntry("ReportUploadApiBaseUrl", "https://api.mlvscan.com",
                     description: "API base URL for report uploads");
 
@@ -81,6 +93,8 @@ namespace MLVScan.MelonLoader
 
                 _enableAutoScan.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _enableAutoDisable.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _blockKnownThreats.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _blockSuspicious.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _minSeverityForDisable.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _scanDirectories.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _suspiciousThreshold.OnEntryValueChanged.Subscribe(OnConfigChanged);
@@ -91,6 +105,7 @@ namespace MLVScan.MelonLoader
                 _reportUploadConsentAsked.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _reportUploadConsentPending.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _pendingReportUploadPath.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _pendingReportUploadVerdictKind.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _reportUploadApiBaseUrl.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _uploadedReportHashes.OnEntryValueChanged.Subscribe(OnConfigChanged);
 
@@ -126,6 +141,8 @@ namespace MLVScan.MelonLoader
             {
                 EnableAutoScan = _enableAutoScan.Value,
                 EnableAutoDisable = _enableAutoDisable.Value,
+                BlockKnownThreats = _blockKnownThreats.Value,
+                BlockSuspicious = _blockSuspicious.Value,
                 MinSeverityForDisable = ParseSeverity(_minSeverityForDisable.Value),
                 ScanDirectories = _scanDirectories.Value,
                 SuspiciousThreshold = _suspiciousThreshold.Value,
@@ -139,6 +156,7 @@ namespace MLVScan.MelonLoader
                 ReportUploadConsentAsked = _reportUploadConsentAsked.Value,
                 ReportUploadConsentPending = _reportUploadConsentPending.Value,
                 PendingReportUploadPath = _pendingReportUploadPath.Value,
+                PendingReportUploadVerdictKind = _pendingReportUploadVerdictKind.Value,
                 ReportUploadApiBaseUrl = _reportUploadApiBaseUrl.Value,
                 UploadedReportHashes = NormalizeHashes(_uploadedReportHashes.Value)
             };
@@ -150,6 +168,8 @@ namespace MLVScan.MelonLoader
             {
                 _enableAutoScan.Value = newConfig.EnableAutoScan;
                 _enableAutoDisable.Value = newConfig.EnableAutoDisable;
+                _blockKnownThreats.Value = newConfig.BlockKnownThreats;
+                _blockSuspicious.Value = newConfig.BlockSuspicious;
                 _minSeverityForDisable.Value = FormatSeverity(newConfig.MinSeverityForDisable);
                 _scanDirectories.Value = newConfig.ScanDirectories;
                 _suspiciousThreshold.Value = newConfig.SuspiciousThreshold;
@@ -160,6 +180,7 @@ namespace MLVScan.MelonLoader
                 _reportUploadConsentAsked.Value = newConfig.ReportUploadConsentAsked;
                 _reportUploadConsentPending.Value = newConfig.ReportUploadConsentPending;
                 _pendingReportUploadPath.Value = newConfig.PendingReportUploadPath ?? string.Empty;
+                _pendingReportUploadVerdictKind.Value = newConfig.PendingReportUploadVerdictKind ?? string.Empty;
                 _reportUploadApiBaseUrl.Value = newConfig.ReportUploadApiBaseUrl;
                 _uploadedReportHashes.Value = NormalizeHashes(newConfig.UploadedReportHashes);
 

--- a/MelonLoader/MelonConfigManager.cs
+++ b/MelonLoader/MelonConfigManager.cs
@@ -19,6 +19,7 @@ namespace MLVScan.MelonLoader
         private readonly MelonPreferences_Entry<bool> _enableScanCache;
         private readonly MelonPreferences_Entry<bool> _blockKnownThreats;
         private readonly MelonPreferences_Entry<bool> _blockSuspicious;
+        private readonly MelonPreferences_Entry<bool> _blockIncompleteScans;
         private readonly MelonPreferences_Entry<string> _minSeverityForDisable;
         private readonly MelonPreferences_Entry<string[]> _scanDirectories;
         private readonly MelonPreferences_Entry<int> _suspiciousThreshold;
@@ -51,7 +52,7 @@ namespace MLVScan.MelonLoader
                     description: "Whether to scan mods at startup");
 
                 _enableAutoDisable = _category.CreateEntry("EnableAutoDisable", true,
-                    description: "Whether to disable suspicious mods");
+                    description: "Whether to automatically disable mods that meet the active blocking policy");
 
                 _enableScanCache = _category.CreateEntry("EnableScanCache", true,
                     description: "Whether to reuse scan results for unchanged files using a local authenticated cache");
@@ -61,6 +62,9 @@ namespace MLVScan.MelonLoader
 
                 _blockSuspicious = _category.CreateEntry("BlockSuspicious", true,
                     description: "Whether to block suspicious unknown behavior that may still be a false positive");
+
+                _blockIncompleteScans = _category.CreateEntry("BlockIncompleteScans", false,
+                    description: "Whether to block mods that could not be fully analyzed and require manual review");
 
                 _minSeverityForDisable = _category.CreateEntry("MinSeverityForDisable", "Medium",
                     description: "Legacy setting from the old severity-based blocking model (no longer used for blocking)");
@@ -124,6 +128,7 @@ namespace MLVScan.MelonLoader
                 _enableScanCache.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _blockKnownThreats.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _blockSuspicious.OnEntryValueChanged.Subscribe(OnConfigChanged);
+                _blockIncompleteScans.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _minSeverityForDisable.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _scanDirectories.OnEntryValueChanged.Subscribe(OnConfigChanged);
                 _suspiciousThreshold.OnEntryValueChanged.Subscribe(OnConfigChanged);
@@ -179,6 +184,7 @@ namespace MLVScan.MelonLoader
                 EnableScanCache = _enableScanCache.Value,
                 BlockKnownThreats = _blockKnownThreats.Value,
                 BlockSuspicious = _blockSuspicious.Value,
+                BlockIncompleteScans = _blockIncompleteScans.Value,
                 MinSeverityForDisable = ParseSeverity(_minSeverityForDisable.Value),
                 ScanDirectories = _scanDirectories.Value,
                 SuspiciousThreshold = _suspiciousThreshold.Value,
@@ -214,6 +220,7 @@ namespace MLVScan.MelonLoader
                 _enableScanCache.Value = newConfig.EnableScanCache;
                 _blockKnownThreats.Value = newConfig.BlockKnownThreats;
                 _blockSuspicious.Value = newConfig.BlockSuspicious;
+                _blockIncompleteScans.Value = newConfig.BlockIncompleteScans;
                 _minSeverityForDisable.Value = FormatSeverity(newConfig.MinSeverityForDisable);
                 _scanDirectories.Value = newConfig.ScanDirectories;
                 _suspiciousThreshold.Value = newConfig.SuspiciousThreshold;

--- a/MelonLoader/MelonEnvironment.cs
+++ b/MelonLoader/MelonEnvironment.cs
@@ -18,7 +18,7 @@ namespace MLVScan.MelonLoader
         public MelonPlatformEnvironment()
         {
             _gameRoot = MelonEnvironment.GameRootDirectory;
-            _dataDir = Path.Combine(_gameRoot, "MLVScan");
+            _dataDir = Path.Combine(MelonEnvironment.UserDataDirectory, "MLVScan");
             _reportsDir = Path.Combine(_dataDir, "Reports");
         }
 
@@ -34,8 +34,7 @@ namespace MLVScan.MelonLoader
         {
             get
             {
-                if (!Directory.Exists(_dataDir))
-                    Directory.CreateDirectory(_dataDir);
+                EnsureDataDirectory();
                 return _dataDir;
             }
         }
@@ -44,8 +43,12 @@ namespace MLVScan.MelonLoader
         {
             get
             {
+                EnsureDataDirectory();
                 if (!Directory.Exists(_reportsDir))
+                {
                     Directory.CreateDirectory(_reportsDir);
+                }
+
                 return _reportsDir;
             }
         }
@@ -92,5 +95,13 @@ namespace MLVScan.MelonLoader
         }
 
         public string PlatformName => "MelonLoader";
+
+        private void EnsureDataDirectory()
+        {
+            if (!Directory.Exists(_dataDir))
+            {
+                Directory.CreateDirectory(_dataDir);
+            }
+        }
     }
 }

--- a/MelonLoader/MelonLoaderPlugin.cs
+++ b/MelonLoader/MelonLoaderPlugin.cs
@@ -110,7 +110,7 @@ namespace MLVScan.MelonLoader
 
             GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
             GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                GetUploadConsentMessage(_pendingUploadModName, _pendingUploadVerdictKind) + "\n\n" +
+                ConsentMessageHelper.GetUploadConsentMessage(_pendingUploadModName, _pendingUploadVerdictKind) + "\n\n" +
                 "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                 "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                 "No: do not upload and do not show this prompt again.");
@@ -683,16 +683,5 @@ namespace MLVScan.MelonLoader
                    threatVerdict?.Kind == ThreatVerdictKind.KnownMalwareFamily;
         }
 
-        private static string GetUploadConsentMessage(string modName, string verdictKind)
-        {
-            var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
-            if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
-                string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
-            {
-                return $"MLVScan identified {label} as likely malware and disabled it.";
-            }
-
-            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
-        }
     }
 }

--- a/MelonLoader/MelonLoaderPlugin.cs
+++ b/MelonLoader/MelonLoaderPlugin.cs
@@ -33,6 +33,7 @@ namespace MLVScan.MelonLoader
         private bool _showUploadConsentPopup;
         private string _pendingUploadPath = string.Empty;
         private string _pendingUploadModName = string.Empty;
+        private string _pendingUploadVerdictKind = string.Empty;
         private List<ScanFinding> _pendingUploadFindings;
 
         private static readonly string[] DefaultWhitelistedHashes =
@@ -109,7 +110,7 @@ namespace MLVScan.MelonLoader
 
             GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
             GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                $"MLVScan flagged {_pendingUploadModName} as suspicious and disabled it.\n\n" +
+                GetUploadConsentMessage(_pendingUploadModName, _pendingUploadVerdictKind) + "\n\n" +
                 "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                 "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                 "No: do not upload and do not show this prompt again.");
@@ -130,12 +131,26 @@ namespace MLVScan.MelonLoader
             if (_configManager == null)
                 return;
 
-            var currentWhitelist = _configManager.GetWhitelistedHashes();
+            var currentWhitelist = (_configManager.GetWhitelistedHashes() ?? Array.Empty<string>())
+                .Where(hash => !string.IsNullOrWhiteSpace(hash))
+                .Select(hash => hash.ToLowerInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
 
-            if (currentWhitelist.Length == 0)
+            var mergedWhitelist = currentWhitelist
+                .Concat(DefaultWhitelistedHashes)
+                .Where(hash => !string.IsNullOrWhiteSpace(hash))
+                .Select(hash => hash.ToLowerInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+
+            if (!mergedWhitelist.SequenceEqual(currentWhitelist, StringComparer.OrdinalIgnoreCase))
             {
-                LoggerInstance.Msg("Initializing default whitelist");
-                _configManager.SetWhitelistedHashes(DefaultWhitelistedHashes);
+                var addedCount = mergedWhitelist.Length - currentWhitelist.Length;
+                LoggerInstance.Msg(currentWhitelist.Length == 0
+                    ? "Initializing default whitelist"
+                    : $"Adding {addedCount} new default whitelist hash(es)");
+                _configManager.SetWhitelistedHashes(mergedWhitelist);
             }
         }
 
@@ -149,18 +164,18 @@ namespace MLVScan.MelonLoader
                     return new Dictionary<string, ScannedPluginResult>();
                 }
 
-                LoggerInstance.Msg("Scanning for suspicious mods...");
+                LoggerInstance.Msg("Scanning mods for threats...");
                 var scanResults = _pluginScanner.ScanAllPlugins(force);
 
                 var filteredResults = scanResults
-                    .Where(kv => kv.Value != null && kv.Value.Findings.Count > 0)
+                    .Where(kv => kv.Value != null && kv.Value.ThreatVerdict?.Kind != ThreatVerdictKind.None)
                     .ToDictionary(kv => kv.Key, kv => kv.Value);
 
                 if (filteredResults.Count > 0)
                 {
                     var disabledMods = _pluginDisabler.DisableSuspiciousPlugins(filteredResults, force);
                     var disabledCount = disabledMods.Count;
-                    LoggerInstance.Msg($"Disabled {disabledCount} suspicious mods");
+                    LoggerInstance.Msg($"Disabled {disabledCount} flagged mods");
 
                     if (disabledCount <= 0)
                         return filteredResults;
@@ -170,7 +185,7 @@ namespace MLVScan.MelonLoader
                 }
                 else
                 {
-                    LoggerInstance.Msg("No suspicious mods found");
+                    LoggerInstance.Msg("No flagged mods found");
                 }
 
                 return filteredResults;
@@ -213,19 +228,19 @@ namespace MLVScan.MelonLoader
                     var actualFindings = scanResult?.Findings ?? new List<ScanFinding>();
                     var threatVerdict = modInfo.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
 
-                    if (actualFindings.Count == 0)
+                    if (actualFindings.Count == 0 && threatVerdict.Kind == ThreatVerdictKind.None)
                     {
                         LoggerInstance.Msg("No specific suspicious patterns were identified.");
                         continue;
                 }
 
-                QueueConsentPromptIfNeeded(accessiblePath, modName, actualFindings);
+                QueueConsentPromptIfNeeded(accessiblePath, modName, actualFindings, threatVerdict);
 
                 var groupedFindings = actualFindings
                     .GroupBy(f => f.Description)
                     .ToDictionary(g => g.Key, g => g.ToList());
 
-                    LoggerInstance.Warning($"Total suspicious patterns found: {actualFindings.Count}");
+                    LoggerInstance.Warning($"Total retained findings: {actualFindings.Count}");
                     LoggerInstance.Warning($"Verdict: {ThreatVerdictTextFormatter.GetVerdictLabel(threatVerdict)}");
                     LoggerInstance.Msg(threatVerdict.Summary);
 
@@ -407,7 +422,7 @@ namespace MLVScan.MelonLoader
                                 }
                             }
 
-                            WriteSecurityNoticeToReport(writer);
+                            WriteSecurityNoticeToReport(writer, threatVerdict);
                         }
                     }
 
@@ -455,7 +470,11 @@ namespace MLVScan.MelonLoader
             LoggerInstance.Warning("====== END OF SCAN REPORT ======");
         }
 
-        private void QueueConsentPromptIfNeeded(string accessiblePath, string modName, List<ScanFinding> findings)
+        private void QueueConsentPromptIfNeeded(
+            string accessiblePath,
+            string modName,
+            List<ScanFinding> findings,
+            ThreatVerdictInfo threatVerdict)
         {
             if (_configManager == null || _showUploadConsentPopup)
             {
@@ -471,10 +490,12 @@ namespace MLVScan.MelonLoader
             _showUploadConsentPopup = true;
             _pendingUploadPath = accessiblePath;
             _pendingUploadModName = modName;
+            _pendingUploadVerdictKind = threatVerdict?.Kind.ToString() ?? string.Empty;
             _pendingUploadFindings = findings;
 
             config.ReportUploadConsentPending = true;
             config.PendingReportUploadPath = accessiblePath ?? string.Empty;
+            config.PendingReportUploadVerdictKind = _pendingUploadVerdictKind;
             _configManager.SaveConfig(config);
 
             LoggerInstance.Warning("MLVScan is waiting for your upload consent decision in the in-game popup.");
@@ -493,6 +514,7 @@ namespace MLVScan.MelonLoader
             config.ReportUploadConsentAsked = true;
             config.ReportUploadConsentPending = false;
             config.PendingReportUploadPath = string.Empty;
+            config.PendingReportUploadVerdictKind = string.Empty;
             config.EnableReportUpload = approved;
             _configManager.SaveConfig(config);
 
@@ -501,6 +523,7 @@ namespace MLVScan.MelonLoader
                 LoggerInstance.Msg("MLVScan report upload declined. You will not be prompted again.");
                 _pendingUploadPath = string.Empty;
                 _pendingUploadModName = string.Empty;
+                _pendingUploadVerdictKind = string.Empty;
                 _pendingUploadFindings = null;
                 return;
             }
@@ -528,6 +551,7 @@ namespace MLVScan.MelonLoader
             {
                 _pendingUploadPath = string.Empty;
                 _pendingUploadModName = string.Empty;
+                _pendingUploadVerdictKind = string.Empty;
                 _pendingUploadFindings = null;
             }
         }
@@ -573,59 +597,100 @@ namespace MLVScan.MelonLoader
         {
             LoggerInstance.Warning("IMPORTANT SECURITY NOTICE");
             LoggerInstance.Msg($"MLVScan has detected and disabled {modName} before it was loaded.");
-            if (threatVerdict?.Kind == ThreatVerdictKind.KnownMaliciousSample ||
-                threatVerdict?.Kind == ThreatVerdictKind.KnownMalwareFamily)
+            if (IsKnownThreatVerdict(threatVerdict))
             {
-                LoggerInstance.Msg("This block was reinforced by a match to previously analyzed malware.");
+                LoggerInstance.Msg("This mod is likely malware because it matched previously analyzed malware intelligence.");
                 LoggerInstance.Msg("If this is your first time running the game with this mod, your PC is likely safe.");
                 LoggerInstance.Msg("However, if you've previously run the game with this mod, your system MAY be infected.");
+                LoggerInstance.Warning("Recommended security steps:");
+                LoggerInstance.Msg("1. Check with the modding community first - no detection is perfect");
+                LoggerInstance.Msg("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
+                LoggerInstance.Msg("   Ask about this mod in the MLVScan thread of #mod-releases to confirm if it's actually malicious");
+                LoggerInstance.Msg("2. Run a full system scan with a trusted antivirus like Malwarebytes");
+                LoggerInstance.Msg("   Malwarebytes is recommended as a free and effective antivirus solution");
+                LoggerInstance.Msg("3. Use Microsoft Safety Scanner for a secondary scan");
+                LoggerInstance.Msg("4. Change important passwords if antivirus shows a threat");
+                LoggerInstance.Warning("Resources for malware removal:");
+                LoggerInstance.Msg("- Malwarebytes: https://www.malwarebytes.com/cybersecurity/basics/how-to-remove-virus-from-computer");
+                LoggerInstance.Msg("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
             }
             else
             {
-                LoggerInstance.Msg("This mod was blocked as a precaution based on suspicious behavior patterns.");
-                LoggerInstance.Msg("Keep in mind that no detection system is perfect, and this mod may still be falsely flagged.");
+                LoggerInstance.Msg("This mod was blocked because it triggered suspicious correlated behavior.");
+                LoggerInstance.Msg("It may still be a false positive, so review the saved report before assuming infection.");
+                LoggerInstance.Warning("Recommended review steps:");
+                LoggerInstance.Msg("1. Check with the modding community first - no detection is perfect");
+                LoggerInstance.Msg("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
+                LoggerInstance.Msg("   Ask about this mod in the MLVScan thread of #mod-releases to confirm if it is actually malicious");
+                LoggerInstance.Msg("2. Review the saved report for the exact behavior that triggered the block");
+                LoggerInstance.Msg("3. Only run a full antivirus scan if you have already executed this mod or still do not trust it");
+                LoggerInstance.Msg("4. Whitelist the SHA256 only if you have independently verified the mod is safe");
             }
-            LoggerInstance.Warning("Recommended security steps:");
-            LoggerInstance.Msg("1. Check with the modding community first - no detection is perfect");
-            LoggerInstance.Msg("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
-            LoggerInstance.Msg("   Ask about this mod in the MLVScan thread of #mod-releases to confirm if it's actually malicious");
-            LoggerInstance.Msg("2. Run a full system scan with a trusted antivirus like Malwarebytes");
-            LoggerInstance.Msg("   Malwarebytes is recommended as a free and effective antivirus solution");
-            LoggerInstance.Msg("3. Use Microsoft Safety Scanner for a secondary scan");
-            LoggerInstance.Msg("4. Change important passwords if antivirus shows a threat");
-            LoggerInstance.Warning("Resources for malware removal:");
-            LoggerInstance.Msg("- Malwarebytes: https://www.malwarebytes.com/cybersecurity/basics/how-to-remove-virus-from-computer");
-            LoggerInstance.Msg("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
         }
 
-        private static void WriteSecurityNoticeToReport(StreamWriter writer)
+        private static void WriteSecurityNoticeToReport(StreamWriter writer, ThreatVerdictInfo threatVerdict)
         {
             writer.WriteLine("\n\n============== SECURITY NOTICE ==============\n");
             writer.WriteLine("IMPORTANT: READ THIS SECURITY INFORMATION\n");
             writer.WriteLine("MLVScan has detected and disabled this mod before it was loaded.");
-            writer.WriteLine("This mod contains code patterns commonly associated with malware.\n");
-            writer.WriteLine("YOUR SYSTEM SECURITY STATUS:");
-            writer.WriteLine("- If this is your FIRST TIME starting the game with this mod installed:");
-            writer.WriteLine("  Your PC is likely SAFE as MLVScan prevented the mod from loading.");
-            writer.WriteLine("\n- If you have PREVIOUSLY PLAYED the game with this mod loaded:");
-            writer.WriteLine("  Your system MAY BE INFECTED with malware. Take action immediately.\n");
-            writer.WriteLine("RECOMMENDED SECURITY STEPS:");
-            writer.WriteLine("1. Check with the modding community first - no detection system is perfect");
-            writer.WriteLine("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
-            writer.WriteLine("   Ask about this mod in the #MLVScan or #report-mods channels to confirm if it's actually malicious");
-            writer.WriteLine("\n2. Run a full system scan with a reputable antivirus program");
-            writer.WriteLine("   Free option: Malwarebytes (https://www.malwarebytes.com/)");
-            writer.WriteLine("   Malwarebytes is recommended as a free and effective antivirus solution");
-            writer.WriteLine("\n3. Run Microsoft Safety Scanner as a secondary check");
-            writer.WriteLine("   Download: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
-            writer.WriteLine("\n4. Update all your software from official sources");
-            writer.WriteLine("\n5. Change passwords for important accounts (from a clean device if possible)");
-            writer.WriteLine("\n6. Monitor your accounts for any suspicious activity");
-            writer.WriteLine("\nDETAILED MALWARE REMOVAL GUIDES:");
-            writer.WriteLine("- Malwarebytes Guide: https://www.malwarebytes.com/cybersecurity/basics/how-to-remove-virus-from-computer");
-            writer.WriteLine("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
-            writer.WriteLine("- XWorm (Common Modding Malware) Removal Guide: https://www.pcrisk.com/removal-guides/27436-xworm-rat");
+            if (IsKnownThreatVerdict(threatVerdict))
+            {
+                writer.WriteLine("This mod is likely malware because it matched previously analyzed malware intelligence.\n");
+                writer.WriteLine("YOUR SYSTEM SECURITY STATUS:");
+                writer.WriteLine("- If this is your FIRST TIME starting the game with this mod installed:");
+                writer.WriteLine("  Your PC is likely SAFE as MLVScan prevented the mod from loading.");
+                writer.WriteLine("\n- If you have PREVIOUSLY PLAYED the game with this mod loaded:");
+                writer.WriteLine("  Your system MAY BE INFECTED with malware. Take action immediately.\n");
+                writer.WriteLine("RECOMMENDED SECURITY STEPS:");
+                writer.WriteLine("1. Check with the modding community first - no detection system is perfect");
+                writer.WriteLine("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
+                writer.WriteLine("   Ask about this mod in the #MLVScan or #report-mods channels to confirm if it is actually malicious");
+                writer.WriteLine("\n2. Run a full system scan with a reputable antivirus program");
+                writer.WriteLine("   Free option: Malwarebytes (https://www.malwarebytes.com/)");
+                writer.WriteLine("   Malwarebytes is recommended as a free and effective antivirus solution");
+                writer.WriteLine("\n3. Run Microsoft Safety Scanner as a secondary check");
+                writer.WriteLine("   Download: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
+                writer.WriteLine("\n4. Update all your software from official sources");
+                writer.WriteLine("\n5. Change passwords for important accounts (from a clean device if possible)");
+                writer.WriteLine("\n6. Monitor your accounts for any suspicious activity");
+                writer.WriteLine("\nDETAILED MALWARE REMOVAL GUIDES:");
+                writer.WriteLine("- Malwarebytes Guide: https://www.malwarebytes.com/cybersecurity/basics/how-to-remove-virus-from-computer");
+                writer.WriteLine("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
+                writer.WriteLine("- XWorm (Common Modding Malware) Removal Guide: https://www.pcrisk.com/removal-guides/27436-xworm-rat");
+            }
+            else
+            {
+                writer.WriteLine("This mod was blocked because it triggered suspicious correlated behavior.\n");
+                writer.WriteLine("IMPORTANT:");
+                writer.WriteLine("- This may still be a false positive.");
+                writer.WriteLine("- Review the report details and verify the mod with trusted community sources before assuming infection.\n");
+                writer.WriteLine("RECOMMENDED REVIEW STEPS:");
+                writer.WriteLine("1. Check with the modding community first - no detection system is perfect");
+                writer.WriteLine("   Join the modding Discord at: https://discord.gg/UD4K4chKak");
+                writer.WriteLine("   Ask about this mod in the #MLVScan or #report-mods channels to confirm if it is actually malicious");
+                writer.WriteLine("\n2. Review the detailed findings and call/data-flow evidence in this report");
+                writer.WriteLine("\n3. Only run a full antivirus scan if you already executed the mod or still do not trust it");
+                writer.WriteLine("\n4. Whitelist the SHA256 only after independent verification");
+            }
             writer.WriteLine("\n=============================================");
+        }
+
+        private static bool IsKnownThreatVerdict(ThreatVerdictInfo threatVerdict)
+        {
+            return threatVerdict?.Kind == ThreatVerdictKind.KnownMaliciousSample ||
+                   threatVerdict?.Kind == ThreatVerdictKind.KnownMalwareFamily;
+        }
+
+        private static string GetUploadConsentMessage(string modName, string verdictKind)
+        {
+            var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
+            if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
+                string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
+            {
+                return $"MLVScan identified {label} as likely malware and disabled it.";
+            }
+
+            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
         }
     }
 }

--- a/MelonLoader/MelonLoaderPlugin.cs
+++ b/MelonLoader/MelonLoaderPlugin.cs
@@ -132,6 +132,7 @@ namespace MLVScan.MelonLoader
                 return;
 
             var currentWhitelist = (_configManager.GetWhitelistedHashes() ?? Array.Empty<string>())
+                .Select(hash => hash?.Trim())
                 .Where(hash => !string.IsNullOrWhiteSpace(hash))
                 .Select(hash => hash.ToLowerInvariant())
                 .Distinct(StringComparer.OrdinalIgnoreCase)
@@ -139,6 +140,7 @@ namespace MLVScan.MelonLoader
 
             var mergedWhitelist = currentWhitelist
                 .Concat(DefaultWhitelistedHashes)
+                .Select(hash => hash?.Trim())
                 .Where(hash => !string.IsNullOrWhiteSpace(hash))
                 .Select(hash => hash.ToLowerInvariant())
                 .Distinct(StringComparer.OrdinalIgnoreCase)

--- a/MelonLoader/MelonLoaderPlugin.cs
+++ b/MelonLoader/MelonLoaderPlugin.cs
@@ -34,6 +34,7 @@ namespace MLVScan.MelonLoader
         private string _pendingUploadPath = string.Empty;
         private string _pendingUploadModName = string.Empty;
         private string _pendingUploadVerdictKind = string.Empty;
+        private bool _pendingUploadWasBlocked = true;
         private List<ScanFinding> _pendingUploadFindings;
 
         private static readonly string[] DefaultWhitelistedHashes =
@@ -110,7 +111,7 @@ namespace MLVScan.MelonLoader
 
             GUI.Box(new Rect(x, y, width, height), "MLVScan Upload Consent");
             GUI.Label(new Rect(x + 20f, y + 40f, width - 40f, 140f),
-                ConsentMessageHelper.GetUploadConsentMessage(_pendingUploadModName, _pendingUploadVerdictKind) + "\n\n" +
+                ConsentMessageHelper.GetUploadConsentMessage(_pendingUploadModName, _pendingUploadVerdictKind, _pendingUploadWasBlocked) + "\n\n" +
                 "Would you like to upload this file to the MLVScan API for human review?\n\n" +
                 "Yes: upload this mod now and enable automatic uploads for future detections.\n" +
                 "No: do not upload and do not show this prompt again.");
@@ -169,28 +170,36 @@ namespace MLVScan.MelonLoader
                 LoggerInstance.Msg("Scanning mods for threats...");
                 var scanResults = _pluginScanner.ScanAllPlugins(force);
 
-                var filteredResults = scanResults
-                    .Where(kv => kv.Value != null && kv.Value.ThreatVerdict?.Kind != ThreatVerdictKind.None)
+                var attentionResults = scanResults
+                    .Where(kv => kv.Value != null && ScanResultFacts.RequiresAttention(kv.Value))
                     .ToDictionary(kv => kv.Key, kv => kv.Value);
 
-                if (filteredResults.Count > 0)
+                if (attentionResults.Count > 0)
                 {
-                    var disabledMods = _pluginDisabler.DisableSuspiciousPlugins(filteredResults, force);
+                    var disabledMods = _pluginDisabler.DisableSuspiciousPlugins(attentionResults, force);
                     var disabledCount = disabledMods.Count;
-                    LoggerInstance.Msg($"Disabled {disabledCount} flagged mods");
+                    var reviewOnlyCount = attentionResults.Count - disabledCount;
 
-                    if (disabledCount <= 0)
-                        return filteredResults;
-                    GenerateDetailedReports(disabledMods, filteredResults);
+                    if (disabledCount > 0)
+                    {
+                        LoggerInstance.Msg($"Disabled {disabledCount} mod(s) that matched the active blocking policy");
+                    }
+
+                    if (reviewOnlyCount > 0)
+                    {
+                        LoggerInstance.Warning($"{reviewOnlyCount} mod(s) require manual review but were not blocked by the current configuration");
+                    }
+
+                    GenerateDetailedReports(disabledMods, attentionResults);
 
                     LoggerInstance.Msg("To whitelist any false positives, add their SHA256 hash to the MLVScan → WhitelistedHashes setting in MelonPreferences.cfg");
                 }
                 else
                 {
-                    LoggerInstance.Msg("No flagged mods found");
+                    LoggerInstance.Msg("No mods requiring action were found");
                 }
 
-                return filteredResults;
+                return attentionResults;
             }
             catch (Exception ex)
             {
@@ -202,6 +211,8 @@ namespace MLVScan.MelonLoader
         private void GenerateDetailedReports(List<DisabledPluginInfo> disabledMods, Dictionary<string, ScannedPluginResult> scanResults)
         {
             var isDeveloperMode = _configManager?.Config?.Scan?.DeveloperMode ?? false;
+            var disabledByPath = (disabledMods ?? new List<DisabledPluginInfo>())
+                .ToDictionary(info => info.OriginalPath, StringComparer.OrdinalIgnoreCase);
 
             if (isDeveloperMode)
             {
@@ -211,55 +222,75 @@ namespace MLVScan.MelonLoader
             LoggerInstance.Warning("======= DETAILED SCAN REPORT =======");
             LoggerInstance.Msg(PlatformConstants.GetFullVersionInfo());
 
-            foreach (var modInfo in disabledMods)
+            foreach (var (scanPath, scanResult) in scanResults.OrderBy(kv => Path.GetFileName(kv.Key), StringComparer.OrdinalIgnoreCase))
             {
-                var modName = Path.GetFileName(modInfo.OriginalPath);
-                var fileHash = modInfo.FileHash;
-                var accessiblePath = File.Exists(modInfo.DisabledPath) ? modInfo.DisabledPath : modInfo.OriginalPath;
+                disabledByPath.TryGetValue(scanPath, out var modInfo);
 
-                    LoggerInstance.Warning($"BLOCKED MOD: {modName}");
-                    LoggerInstance.Msg($"SHA256 Hash: {fileHash}");
-                    LoggerInstance.Msg("-------------------------------");
-
-                    if (!scanResults.TryGetValue(modInfo.OriginalPath, out var scanResult))
-                    {
-                        LoggerInstance.Error("Could not find scan results for disabled mod");
-                        continue;
-                    }
-
-                    var actualFindings = scanResult?.Findings ?? new List<ScanFinding>();
-                    var threatVerdict = modInfo.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
-
-                    if (actualFindings.Count == 0 && threatVerdict.Kind == ThreatVerdictKind.None)
-                    {
-                        LoggerInstance.Msg("No specific suspicious patterns were identified.");
-                        continue;
-                }
-
-                QueueConsentPromptIfNeeded(accessiblePath, modName, actualFindings, threatVerdict);
-
+                var wasBlocked = modInfo != null;
+                var modName = Path.GetFileName(scanPath);
+                var fileHash = modInfo?.FileHash ?? scanResult?.FileHash ?? string.Empty;
+                var originalPath = modInfo?.OriginalPath ?? scanResult?.FilePath ?? string.Empty;
+                var accessiblePath = wasBlocked && File.Exists(modInfo.DisabledPath)
+                    ? modInfo.DisabledPath
+                    : (scanResult?.FilePath ?? scanPath);
+                var actualFindings = scanResult?.Findings ?? new List<ScanFinding>();
+                var threatVerdict = modInfo?.ThreatVerdict ?? scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
+                var scanStatus = modInfo?.ScanStatus ?? scanResult?.ScanStatus ?? new ScanStatusInfo();
+                var outcomeLabel = ThreatVerdictTextFormatter.GetOutcomeLabel(scanResult);
+                var outcomeSummary = ThreatVerdictTextFormatter.GetOutcomeSummary(scanResult);
                 var groupedFindings = actualFindings
                     .GroupBy(f => f.Description)
                     .ToDictionary(g => g.Key, g => g.ToList());
 
-                    LoggerInstance.Warning($"Total retained findings: {actualFindings.Count}");
-                    LoggerInstance.Warning($"Verdict: {ThreatVerdictTextFormatter.GetVerdictLabel(threatVerdict)}");
-                    LoggerInstance.Msg(threatVerdict.Summary);
+                LoggerInstance.Warning($"{(wasBlocked ? "BLOCKED MOD" : "REVIEW REQUIRED")}: {modName}");
+                LoggerInstance.Msg($"SHA256 Hash: {fileHash}");
+                LoggerInstance.Msg("-------------------------------");
 
-                    var familyName = ThreatVerdictTextFormatter.GetPrimaryFamilyLabel(threatVerdict);
-                    if (!string.IsNullOrWhiteSpace(familyName))
-                    {
-                        LoggerInstance.Msg($"Family: {familyName}");
-                    }
+                if (actualFindings.Count == 0 &&
+                    threatVerdict.Kind == ThreatVerdictKind.None &&
+                    scanStatus.Kind == ScanStatusKind.Complete)
+                {
+                    LoggerInstance.Msg("No specific findings were retained.");
+                    continue;
+                }
 
-                    var confidenceLabel = ThreatVerdictTextFormatter.GetConfidenceLabel(threatVerdict);
-                    if (!string.IsNullOrWhiteSpace(confidenceLabel))
-                    {
-                        LoggerInstance.Msg($"Confidence: {confidenceLabel}");
-                    }
+                if (threatVerdict.Kind != ThreatVerdictKind.None)
+                {
+                    QueueConsentPromptIfNeeded(accessiblePath, modName, actualFindings, threatVerdict, wasBlocked);
+                }
 
-                    var severityCounts = actualFindings
-                        .GroupBy(f => f.Severity)
+                LoggerInstance.Warning($"Total retained findings: {actualFindings.Count}");
+                if (!string.IsNullOrWhiteSpace(outcomeLabel))
+                {
+                    LoggerInstance.Warning($"Outcome: {outcomeLabel}");
+                }
+
+                if (!string.IsNullOrWhiteSpace(outcomeSummary))
+                {
+                    LoggerInstance.Msg(outcomeSummary);
+                }
+
+                if (scanStatus.Kind != ScanStatusKind.Complete)
+                {
+                    LoggerInstance.Msg(wasBlocked
+                        ? "Action: blocked by current incomplete-scan policy."
+                        : "Action: manual review required; not blocked by current config.");
+                }
+
+                var familyName = ThreatVerdictTextFormatter.GetPrimaryFamilyLabel(threatVerdict);
+                if (!string.IsNullOrWhiteSpace(familyName))
+                {
+                    LoggerInstance.Msg($"Family: {familyName}");
+                }
+
+                var confidenceLabel = ThreatVerdictTextFormatter.GetConfidenceLabel(threatVerdict);
+                if (!string.IsNullOrWhiteSpace(confidenceLabel))
+                {
+                    LoggerInstance.Msg($"Confidence: {confidenceLabel}");
+                }
+
+                var severityCounts = actualFindings
+                    .GroupBy(f => f.Severity)
                     .OrderByDescending(g => (int)g.Key)
                     .ToDictionary(g => g.Key, g => g.Count());
 
@@ -270,30 +301,29 @@ namespace MLVScan.MelonLoader
                     LoggerInstance.Msg($"  {severityLabel}: {severityCount.Value} issue(s)");
                 }
 
-                    LoggerInstance.Msg("-------------------------------");
+                LoggerInstance.Msg("-------------------------------");
 
-                    var topSignals = ThreatVerdictTextFormatter.GetTopFindingSummaries(actualFindings, 3);
-                    if (topSignals.Count > 0)
+                var topSignals = ThreatVerdictTextFormatter.GetTopFindingSummaries(actualFindings, 3);
+                if (topSignals.Count > 0)
+                {
+                    LoggerInstance.Warning("Top signals:");
+                    foreach (var signal in topSignals)
                     {
-                        LoggerInstance.Warning("Top signals:");
-                        foreach (var signal in topSignals)
-                        {
-                            LoggerInstance.Msg($"  - {signal}");
-                        }
+                        LoggerInstance.Msg($"  - {signal}");
                     }
+                }
 
-                    if (isDeveloperMode)
-                    {
-                        LoggerInstance.Msg("Developer mode is enabled. Full remediation guidance is included in the report file.");
-                    }
+                if (isDeveloperMode)
+                {
+                    LoggerInstance.Msg("Developer mode is enabled. Full remediation guidance is included in the report file.");
+                }
 
-                    LoggerInstance.Msg("Full technical details were written to the saved report file for human review.");
-                    LoggerInstance.Msg("-------------------------------");
-                    DisplaySecurityNotice(modName, threatVerdict);
+                LoggerInstance.Msg("Full technical details were written to the saved report file for human review.");
+                LoggerInstance.Msg("-------------------------------");
+                DisplaySecurityNotice(modName, threatVerdict, scanStatus, wasBlocked);
 
                 try
                 {
-                    // Generate report and prompt files
                     var reportDirectory = _environment?.ReportsDirectory
                         ?? Path.Combine(MelonEnvironment.UserDataDirectory, "MLVScan", "Reports");
                     if (!Directory.Exists(reportDirectory))
@@ -309,7 +339,9 @@ namespace MLVScan.MelonLoader
                         Directory.CreateDirectory(promptDirectory);
                     }
 
-                    if (_configManager?.Config?.DumpFullIlReports == true && _ilDumpService != null)
+                    if (_configManager?.Config?.DumpFullIlReports == true &&
+                        _ilDumpService != null &&
+                        scanStatus.Kind == ScanStatusKind.Complete)
                     {
                         var ilDirectory = Path.Combine(reportDirectory, "IL");
                         var ilDumpPath = Path.Combine(ilDirectory, $"{modName}_{timestamp}.il.txt");
@@ -323,31 +355,43 @@ namespace MLVScan.MelonLoader
                             LoggerInstance.Warning("Failed to dump IL for this mod (see logs for details).");
                         }
                     }
+                    else if (_configManager?.Config?.DumpFullIlReports == true &&
+                             scanStatus.Kind == ScanStatusKind.RequiresReview)
+                    {
+                        LoggerInstance.Warning("Skipped full IL dump because this file was not fully analyzed by the loader.");
+                    }
 
-                    var promptGenerator = _serviceFactory.CreatePromptGenerator();
+                    var promptGenerator = scanStatus.Kind == ScanStatusKind.Complete
+                        ? _serviceFactory.CreatePromptGenerator()
+                        : null;
 
                     using (var writer = new StreamWriter(reportPath))
                     {
                         if (isDeveloperMode && _developerReportGenerator != null)
                         {
-                            // Developer-friendly report
-                            var devReport = _developerReportGenerator.GenerateFileReport(modName, fileHash, actualFindings, threatVerdict);
+                            var devReport = _developerReportGenerator.GenerateFileReport(modName, fileHash, actualFindings, threatVerdict, scanStatus);
                             writer.Write(devReport);
                         }
                         else
                         {
-                            // Standard security report
-                            writer.WriteLine($"MLVScan Security Report");
+                            writer.WriteLine("MLVScan Security Report");
                             writer.WriteLine(PlatformConstants.GetFullVersionInfo());
                             writer.WriteLine($"Generated: {DateTime.Now}");
                             writer.WriteLine($"Mod File: {modName}");
+                            writer.WriteLine($"Outcome: {outcomeLabel}");
+                            if (!string.IsNullOrWhiteSpace(outcomeSummary))
+                            {
+                                writer.WriteLine($"Outcome Summary: {outcomeSummary}");
+                            }
+                            writer.WriteLine($"Action Taken: {(wasBlocked ? "Blocked" : "Manual review required (not blocked by current config)")}");
                             writer.WriteLine($"SHA256 Hash: {fileHash}");
-                            writer.WriteLine($"Original Path: {modInfo.OriginalPath}");
-                            writer.WriteLine($"Disabled Path: {modInfo.DisabledPath}");
+                            writer.WriteLine($"Original Path: {originalPath}");
+                            writer.WriteLine($"{(wasBlocked ? "Disabled Path" : "Current Path")}: {accessiblePath}");
                             writer.WriteLine($"Path Used For Analysis: {accessiblePath}");
-                            writer.WriteLine($"Total Suspicious Patterns: {actualFindings.Count}");
+                            writer.WriteLine($"Total Retained Findings: {actualFindings.Count}");
                             writer.WriteLine();
                             ThreatVerdictTextFormatter.WriteThreatVerdictSection(writer, threatVerdict);
+                            ThreatVerdictTextFormatter.WriteScanStatusSection(writer, scanStatus);
                             writer.WriteLine("\nSeverity Breakdown:");
                             foreach (var severityCount in severityCounts)
                             {
@@ -425,15 +469,22 @@ namespace MLVScan.MelonLoader
                                 }
                             }
 
-                            WriteSecurityNoticeToReport(writer, threatVerdict);
+                            WriteSecurityNoticeToReport(writer, threatVerdict, scanStatus, wasBlocked);
                         }
                     }
 
-                    // Generate LLM analysis prompt
-                    var promptSaved = promptGenerator.SavePromptToFile(
-                        accessiblePath,
-                        actualFindings,
-                        promptDirectory);
+                    var promptSaved = false;
+                    if (promptGenerator != null)
+                    {
+                        promptSaved = promptGenerator.SavePromptToFile(
+                            accessiblePath,
+                            actualFindings,
+                            promptDirectory);
+                    }
+                    else if (scanStatus.Kind == ScanStatusKind.RequiresReview)
+                    {
+                        LoggerInstance.Warning("Skipped LLM prompt generation because this file was not fully analyzed by the loader.");
+                    }
 
                     if (promptSaved)
                     {
@@ -446,7 +497,9 @@ namespace MLVScan.MelonLoader
                         LoggerInstance.Msg($"Detailed report saved to: {reportPath}");
                     }
 
-                    if (_configManager?.Config?.EnableReportUpload == true && _reportUploadService != null)
+                    if (_configManager?.Config?.EnableReportUpload == true &&
+                        _reportUploadService != null &&
+                        threatVerdict.Kind != ThreatVerdictKind.None)
                     {
                         try
                         {
@@ -477,7 +530,8 @@ namespace MLVScan.MelonLoader
             string accessiblePath,
             string modName,
             List<ScanFinding> findings,
-            ThreatVerdictInfo threatVerdict)
+            ThreatVerdictInfo threatVerdict,
+            bool wasBlocked)
         {
             if (_configManager == null || _showUploadConsentPopup)
             {
@@ -494,6 +548,7 @@ namespace MLVScan.MelonLoader
             _pendingUploadPath = accessiblePath;
             _pendingUploadModName = modName;
             _pendingUploadVerdictKind = threatVerdict?.Kind.ToString() ?? string.Empty;
+            _pendingUploadWasBlocked = wasBlocked;
             _pendingUploadFindings = findings;
 
             config.ReportUploadConsentPending = true;
@@ -527,6 +582,7 @@ namespace MLVScan.MelonLoader
                 _pendingUploadPath = string.Empty;
                 _pendingUploadModName = string.Empty;
                 _pendingUploadVerdictKind = string.Empty;
+                _pendingUploadWasBlocked = true;
                 _pendingUploadFindings = null;
                 return;
             }
@@ -555,6 +611,7 @@ namespace MLVScan.MelonLoader
                 _pendingUploadPath = string.Empty;
                 _pendingUploadModName = string.Empty;
                 _pendingUploadVerdictKind = string.Empty;
+                _pendingUploadWasBlocked = true;
                 _pendingUploadFindings = null;
             }
         }
@@ -596,10 +653,16 @@ namespace MLVScan.MelonLoader
             };
         }
 
-        private void DisplaySecurityNotice(string modName, ThreatVerdictInfo threatVerdict)
+        private void DisplaySecurityNotice(
+            string modName,
+            ThreatVerdictInfo threatVerdict,
+            ScanStatusInfo scanStatus,
+            bool wasBlocked)
         {
             LoggerInstance.Warning("IMPORTANT SECURITY NOTICE");
-            LoggerInstance.Msg($"MLVScan has detected and disabled {modName} before it was loaded.");
+            LoggerInstance.Msg(wasBlocked
+                ? $"MLVScan detected and disabled {modName} before it was loaded."
+                : $"MLVScan flagged {modName} for review but did not block it under the current configuration.");
             if (IsKnownThreatVerdict(threatVerdict))
             {
                 LoggerInstance.Msg("This mod is likely malware because it matched previously analyzed malware intelligence.");
@@ -617,9 +680,9 @@ namespace MLVScan.MelonLoader
                 LoggerInstance.Msg("- Malwarebytes: https://www.malwarebytes.com/cybersecurity/basics/how-to-remove-virus-from-computer");
                 LoggerInstance.Msg("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
             }
-            else
+            else if (threatVerdict?.Kind == ThreatVerdictKind.Suspicious)
             {
-                LoggerInstance.Msg("This mod was blocked because it triggered suspicious correlated behavior.");
+                LoggerInstance.Msg("This mod was flagged because it triggered suspicious correlated behavior.");
                 LoggerInstance.Msg("It may still be a false positive, so review the saved report before assuming infection.");
                 LoggerInstance.Warning("Recommended review steps:");
                 LoggerInstance.Msg("1. Check with the modding community first - no detection is perfect");
@@ -629,13 +692,33 @@ namespace MLVScan.MelonLoader
                 LoggerInstance.Msg("3. Only run a full antivirus scan if you have already executed this mod or still do not trust it");
                 LoggerInstance.Msg("4. Whitelist the SHA256 only if you have independently verified the mod is safe");
             }
+            else if (scanStatus?.Kind == ScanStatusKind.RequiresReview)
+            {
+                LoggerInstance.Msg("This mod could not be fully analyzed by the loader because it exceeded the current in-memory scan limit.");
+                LoggerInstance.Msg("MLVScan still calculated its SHA-256 hash and checked exact known-malicious sample matches.");
+                LoggerInstance.Warning("Recommended review steps:");
+                LoggerInstance.Msg("1. Review the saved report before assuming the mod is safe");
+                LoggerInstance.Msg("2. Validate the mod with trusted community sources or the original author");
+                LoggerInstance.Msg("3. Enable BlockIncompleteScans if you want oversized or incomplete scans blocked automatically");
+                LoggerInstance.Msg("4. Whitelist the SHA256 only after independent verification");
+            }
+            else
+            {
+                LoggerInstance.Msg("Review the saved report before deciding whether to whitelist this mod.");
+            }
         }
 
-        private static void WriteSecurityNoticeToReport(StreamWriter writer, ThreatVerdictInfo threatVerdict)
+        private static void WriteSecurityNoticeToReport(
+            StreamWriter writer,
+            ThreatVerdictInfo threatVerdict,
+            ScanStatusInfo scanStatus,
+            bool wasBlocked)
         {
             writer.WriteLine("\n\n============== SECURITY NOTICE ==============\n");
             writer.WriteLine("IMPORTANT: READ THIS SECURITY INFORMATION\n");
-            writer.WriteLine("MLVScan has detected and disabled this mod before it was loaded.");
+            writer.WriteLine(wasBlocked
+                ? "MLVScan detected and disabled this mod before it was loaded."
+                : "MLVScan flagged this mod for review but did not block it under the current configuration.");
             if (IsKnownThreatVerdict(threatVerdict))
             {
                 writer.WriteLine("This mod is likely malware because it matched previously analyzed malware intelligence.\n");
@@ -661,9 +744,9 @@ namespace MLVScan.MelonLoader
                 writer.WriteLine("- Microsoft Safety Scanner: https://learn.microsoft.com/en-us/defender-endpoint/safety-scanner-download");
                 writer.WriteLine("- XWorm (Common Modding Malware) Removal Guide: https://www.pcrisk.com/removal-guides/27436-xworm-rat");
             }
-            else
+            else if (threatVerdict?.Kind == ThreatVerdictKind.Suspicious)
             {
-                writer.WriteLine("This mod was blocked because it triggered suspicious correlated behavior.\n");
+                writer.WriteLine("This mod was flagged because it triggered suspicious correlated behavior.\n");
                 writer.WriteLine("IMPORTANT:");
                 writer.WriteLine("- This may still be a false positive.");
                 writer.WriteLine("- Review the report details and verify the mod with trusted community sources before assuming infection.\n");
@@ -673,6 +756,19 @@ namespace MLVScan.MelonLoader
                 writer.WriteLine("   Ask about this mod in the #MLVScan or #report-mods channels to confirm if it is actually malicious");
                 writer.WriteLine("\n2. Review the detailed findings and call/data-flow evidence in this report");
                 writer.WriteLine("\n3. Only run a full antivirus scan if you already executed the mod or still do not trust it");
+                writer.WriteLine("\n4. Whitelist the SHA256 only after independent verification");
+            }
+            else if (scanStatus?.Kind == ScanStatusKind.RequiresReview)
+            {
+                writer.WriteLine("This mod could not be fully analyzed by the loader because it exceeded the current in-memory scan limit.\n");
+                writer.WriteLine("IMPORTANT:");
+                writer.WriteLine("- MLVScan still calculated the SHA-256 hash and checked exact known-malicious sample matches.");
+                writer.WriteLine("- No retained malicious verdict was produced, but the file was not fully analyzed.");
+                writer.WriteLine("- Review the report details and verify the mod with trusted community sources before assuming it is safe.\n");
+                writer.WriteLine("RECOMMENDED REVIEW STEPS:");
+                writer.WriteLine("1. Review the report details and confirm whether this mod is expected to be unusually large");
+                writer.WriteLine("\n2. Validate the mod with the original author or trusted community sources");
+                writer.WriteLine("\n3. Enable BlockIncompleteScans if you want oversized or incomplete scans blocked automatically");
                 writer.WriteLine("\n4. Whitelist the SHA256 only after independent verification");
             }
             writer.WriteLine("\n=============================================");

--- a/MelonLoader/MelonLoaderPlugin.cs
+++ b/MelonLoader/MelonLoaderPlugin.cs
@@ -294,7 +294,8 @@ namespace MLVScan.MelonLoader
                 try
                 {
                     // Generate report and prompt files
-                    var reportDirectory = Path.Combine(MelonEnvironment.UserDataDirectory, "MLVScan", "Reports");
+                    var reportDirectory = _environment?.ReportsDirectory
+                        ?? Path.Combine(MelonEnvironment.UserDataDirectory, "MLVScan", "Reports");
                     if (!Directory.Exists(reportDirectory))
                     {
                         Directory.CreateDirectory(reportDirectory);

--- a/MelonLoader/MelonLoaderServiceFactory.cs
+++ b/MelonLoader/MelonLoaderServiceFactory.cs
@@ -4,6 +4,7 @@ using MLVScan.Abstractions;
 using MLVScan.Adapters;
 using MLVScan.Models;
 using MLVScan.Services;
+using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.MelonLoader
 {
@@ -18,12 +19,14 @@ namespace MLVScan.MelonLoader
         private readonly MelonConfigManager _configManager;
         private readonly MelonPlatformEnvironment _environment;
         private readonly MLVScanConfig _fallbackConfig;
+        private readonly LoaderScanTelemetryHub _telemetry;
 
         public MelonLoaderServiceFactory(MelonLogger.Instance logger)
         {
             _melonLogger = logger ?? throw new ArgumentNullException(nameof(logger));
             _scanLogger = new MelonScanLogger(logger);
-            _resolverProvider = new GameAssemblyResolverProvider();
+            _telemetry = new LoaderScanTelemetryHub();
+            _resolverProvider = new GameAssemblyResolverProvider(_telemetry);
             _environment = new MelonPlatformEnvironment();
             _fallbackConfig = new MLVScanConfig();
 
@@ -73,7 +76,8 @@ namespace MLVScan.MelonLoader
                 _resolverProvider,
                 config,
                 _configManager,
-                _environment);
+                _environment,
+                _telemetry);
         }
 
         public MelonPluginDisabler CreatePluginDisabler()

--- a/MelonLoader/MelonPluginScanner.cs
+++ b/MelonLoader/MelonPluginScanner.cs
@@ -33,6 +33,12 @@ namespace MLVScan.MelonLoader
         protected override IEnumerable<string> GetScanDirectories()
         {
             var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var builtInRoots = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                Path.GetFullPath(Path.Combine(_environment.GameRootDirectory, "Mods")),
+                Path.GetFullPath(Path.Combine(_environment.GameRootDirectory, "Plugins")),
+                Path.GetFullPath(Path.Combine(_environment.GameRootDirectory, "UserLibs"))
+            };
 
             if (Config.IncludeMods)
             {
@@ -49,11 +55,9 @@ namespace MLVScan.MelonLoader
                 AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
             }
 
-            foreach (var scanDir in Config.ScanDirectories)
+            foreach (var scanDir in Config.ScanDirectories ?? Array.Empty<string>())
             {
-                AddIfPresent(Path.IsPathRooted(scanDir)
-                    ? scanDir
-                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+                AddLegacyIfPresent(scanDir);
             }
 
             if (Config.IncludeThunderstoreProfiles)
@@ -77,6 +81,25 @@ namespace MLVScan.MelonLoader
                 }
 
                 emitted.Add(Path.GetFullPath(path));
+            }
+
+            void AddLegacyIfPresent(string scanDir)
+            {
+                if (string.IsNullOrWhiteSpace(scanDir))
+                {
+                    return;
+                }
+
+                var resolvedPath = Path.GetFullPath(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+
+                if (builtInRoots.Contains(resolvedPath))
+                {
+                    return;
+                }
+
+                AddIfPresent(resolvedPath);
             }
         }
 

--- a/MelonLoader/MelonPluginScanner.cs
+++ b/MelonLoader/MelonPluginScanner.cs
@@ -129,16 +129,19 @@ namespace MLVScan.MelonLoader
             AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Plugins"));
             AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
 
-            foreach (var scanDir in Config.ScanDirectories)
+            foreach (var scanDir in Config.ScanDirectories ?? Array.Empty<string>())
             {
                 AddIfPresent(Path.IsPathRooted(scanDir)
                     ? scanDir
                     : Path.Combine(_environment.GameRootDirectory, scanDir));
             }
 
-            foreach (var thunderstoreRoot in GetThunderstoreDirectories())
+            if (Config.IncludeThunderstoreProfiles)
             {
-                AddIfPresent(thunderstoreRoot);
+                foreach (var thunderstoreRoot in GetThunderstoreDirectories())
+                {
+                    AddIfPresent(thunderstoreRoot);
+                }
             }
 
             return emitted;

--- a/MelonLoader/MelonPluginScanner.cs
+++ b/MelonLoader/MelonPluginScanner.cs
@@ -4,6 +4,7 @@ using System.IO;
 using MelonLoader.Utils;
 using MLVScan.Abstractions;
 using MLVScan.Models;
+using MLVScan.Services.Caching;
 using MLVScan.Services;
 
 namespace MLVScan.MelonLoader
@@ -95,8 +96,17 @@ namespace MLVScan.MelonLoader
             }
         }
 
+        /// <summary>
+        /// Resolves Thunderstore profile mod folders from the Windows AppData layout only.
+        /// GetThunderstoreDirectories uses RuntimeInformationHelper to skip non-Windows platforms.
+        /// </summary>
         private static IEnumerable<string> GetThunderstoreDirectories()
         {
+            if (!RuntimeInformationHelper.IsWindows)
+            {
+                yield break;
+            }
+
             string appDataPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData);
             string thunderstoreBasePath = Path.Combine(appDataPath, "Thunderstore Mod Manager", "DataFolder");
 

--- a/MelonLoader/MelonPluginScanner.cs
+++ b/MelonLoader/MelonPluginScanner.cs
@@ -22,16 +22,58 @@ namespace MLVScan.MelonLoader
             MLVScanConfig config,
             IConfigManager configManager,
             MelonPlatformEnvironment environment)
-            : base(logger, resolverProvider, config, configManager)
+            : base(logger, resolverProvider, config, configManager, environment)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
         protected override IEnumerable<string> GetScanDirectories()
         {
+            var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (Config.IncludeMods)
+            {
+                AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
+            }
+
+            if (Config.IncludePlugins)
+            {
+                AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Plugins"));
+            }
+
+            if (Config.IncludeUserLibs)
+            {
+                AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
+            }
+
             foreach (var scanDir in Config.ScanDirectories)
             {
-                yield return Path.Combine(_environment.GameRootDirectory, scanDir);
+                AddIfPresent(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+            }
+
+            if (Config.IncludeThunderstoreProfiles)
+            {
+                foreach (var thunderstoreRoot in GetThunderstoreDirectories())
+                {
+                    AddIfPresent(thunderstoreRoot);
+                }
+            }
+
+            foreach (var path in emitted)
+            {
+                yield return path;
+            }
+
+            void AddIfPresent(string path)
+            {
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    return;
+                }
+
+                emitted.Add(Path.GetFullPath(path));
             }
         }
 
@@ -53,53 +95,38 @@ namespace MLVScan.MelonLoader
             }
         }
 
-        protected override void OnScanComplete(Dictionary<string, ScannedPluginResult> results)
+        private static IEnumerable<string> GetThunderstoreDirectories()
         {
-            // Also scan Thunderstore Mod Manager directories
-            ScanThunderstoreModManager(results);
-        }
+            string appDataPath = System.Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData);
+            string thunderstoreBasePath = Path.Combine(appDataPath, "Thunderstore Mod Manager", "DataFolder");
 
-        private void ScanThunderstoreModManager(Dictionary<string, ScannedPluginResult> results)
-        {
-            try
+            if (!Directory.Exists(thunderstoreBasePath))
             {
-                string appDataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-                string thunderstoreBasePath = Path.Combine(appDataPath, "Thunderstore Mod Manager", "DataFolder");
+                yield break;
+            }
 
-                if (!Directory.Exists(thunderstoreBasePath))
-                    return;
-
-                // Find game folders
-                foreach (var gameFolder in Directory.GetDirectories(thunderstoreBasePath))
+            foreach (var gameFolder in Directory.GetDirectories(thunderstoreBasePath))
+            {
+                string profilesPath = Path.Combine(gameFolder, "profiles");
+                if (!Directory.Exists(profilesPath))
                 {
-                    // Scan profiles
-                    string profilesPath = Path.Combine(gameFolder, "profiles");
-                    if (!Directory.Exists(profilesPath))
-                        continue;
+                    continue;
+                }
 
-                    foreach (var profileFolder in Directory.GetDirectories(profilesPath))
+                foreach (var profileFolder in Directory.GetDirectories(profilesPath))
+                {
+                    var modsPath = Path.Combine(profileFolder, "Mods");
+                    if (Directory.Exists(modsPath))
                     {
-                        // Scan Mods directory
-                        string modsPath = Path.Combine(profileFolder, "Mods");
-                        if (Directory.Exists(modsPath))
-                        {
-                            Logger.Info($"Scanning Thunderstore profile mods: {modsPath}");
-                            ScanDirectory(modsPath, results);
-                        }
+                        yield return modsPath;
+                    }
 
-                        // Scan Plugins directory
-                        string pluginsPath = Path.Combine(profileFolder, "Plugins");
-                        if (Directory.Exists(pluginsPath))
-                        {
-                            Logger.Info($"Scanning Thunderstore profile plugins: {pluginsPath}");
-                            ScanDirectory(pluginsPath, results);
-                        }
+                    var pluginsPath = Path.Combine(profileFolder, "Plugins");
+                    if (Directory.Exists(pluginsPath))
+                    {
+                        yield return pluginsPath;
                     }
                 }
-            }
-            catch (Exception ex)
-            {
-                Logger.Error($"Error scanning Thunderstore Mod Manager directories: {ex.Message}");
             }
         }
     }

--- a/MelonLoader/MelonPluginScanner.cs
+++ b/MelonLoader/MelonPluginScanner.cs
@@ -5,6 +5,7 @@ using MelonLoader.Utils;
 using MLVScan.Abstractions;
 using MLVScan.Models;
 using MLVScan.Services.Caching;
+using MLVScan.Services.Diagnostics;
 using MLVScan.Services;
 
 namespace MLVScan.MelonLoader
@@ -22,8 +23,9 @@ namespace MLVScan.MelonLoader
             IAssemblyResolverProvider resolverProvider,
             MLVScanConfig config,
             IConfigManager configManager,
-            MelonPlatformEnvironment environment)
-            : base(logger, resolverProvider, config, configManager, environment)
+            MelonPlatformEnvironment environment,
+            LoaderScanTelemetryHub telemetry)
+            : base(logger, resolverProvider, config, configManager, environment, telemetry)
         {
             _environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
@@ -96,6 +98,39 @@ namespace MLVScan.MelonLoader
             }
         }
 
+        protected override IEnumerable<string> GetResolverDirectories()
+        {
+            var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Mods"));
+            AddIfPresent(Path.Combine(_environment.GameRootDirectory, "Plugins"));
+            AddIfPresent(Path.Combine(_environment.GameRootDirectory, "UserLibs"));
+
+            foreach (var scanDir in Config.ScanDirectories)
+            {
+                AddIfPresent(Path.IsPathRooted(scanDir)
+                    ? scanDir
+                    : Path.Combine(_environment.GameRootDirectory, scanDir));
+            }
+
+            foreach (var thunderstoreRoot in GetThunderstoreDirectories())
+            {
+                AddIfPresent(thunderstoreRoot);
+            }
+
+            return emitted;
+
+            void AddIfPresent(string path)
+            {
+                if (string.IsNullOrWhiteSpace(path) || !Directory.Exists(path))
+                {
+                    return;
+                }
+
+                emitted.Add(Path.GetFullPath(path));
+            }
+        }
+
         /// <summary>
         /// Resolves Thunderstore profile mod folders from the Windows AppData layout only.
         /// GetThunderstoreDirectories uses RuntimeInformationHelper to skip non-Windows platforms.
@@ -115,7 +150,7 @@ namespace MLVScan.MelonLoader
                 yield break;
             }
 
-            foreach (var gameFolder in Directory.GetDirectories(thunderstoreBasePath))
+            foreach (var gameFolder in SafeGetDirectories(thunderstoreBasePath))
             {
                 string profilesPath = Path.Combine(gameFolder, "profiles");
                 if (!Directory.Exists(profilesPath))
@@ -123,7 +158,7 @@ namespace MLVScan.MelonLoader
                     continue;
                 }
 
-                foreach (var profileFolder in Directory.GetDirectories(profilesPath))
+                foreach (var profileFolder in SafeGetDirectories(profilesPath))
                 {
                     var modsPath = Path.Combine(profileFolder, "Mods");
                     if (Directory.Exists(modsPath))
@@ -137,6 +172,32 @@ namespace MLVScan.MelonLoader
                         yield return pluginsPath;
                     }
                 }
+            }
+        }
+
+        private static IEnumerable<string> SafeGetDirectories(string path)
+        {
+            string[] directories;
+            try
+            {
+                directories = Directory.GetDirectories(path);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                yield break;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                yield break;
+            }
+            catch (IOException)
+            {
+                yield break;
+            }
+
+            foreach (var directory in directories)
+            {
+                yield return directory;
             }
         }
     }

--- a/Models/MLVScanConfig.cs
+++ b/Models/MLVScanConfig.cs
@@ -26,6 +26,11 @@ public class MLVScanConfig
     public bool EnableAutoDisable { get; set; } = true;
 
     /// <summary>
+    /// Enable/disable persistent local scan result reuse for unchanged files.
+    /// </summary>
+    public bool EnableScanCache { get; set; } = true;
+
+    /// <summary>
     /// Whether to block mods that match a known threat family or exact malicious sample.
     /// </summary>
     public bool BlockKnownThreats { get; set; } = true;

--- a/Models/MLVScanConfig.cs
+++ b/Models/MLVScanConfig.cs
@@ -41,6 +41,11 @@ public class MLVScanConfig
     public bool BlockSuspicious { get; set; } = true;
 
     /// <summary>
+    /// Whether to block files that could not be fully analyzed and require manual review.
+    /// </summary>
+    public bool BlockIncompleteScans { get; set; } = false;
+
+    /// <summary>
     /// Legacy severity threshold from the rule-first blocking model.
     /// Retained for one compatibility window but no longer used for blocking decisions.
     /// </summary>

--- a/Models/MLVScanConfig.cs
+++ b/Models/MLVScanConfig.cs
@@ -26,7 +26,18 @@ public class MLVScanConfig
     public bool EnableAutoDisable { get; set; } = true;
 
     /// <summary>
-    /// Minimum severity level to trigger disabling.
+    /// Whether to block mods that match a known threat family or exact malicious sample.
+    /// </summary>
+    public bool BlockKnownThreats { get; set; } = true;
+
+    /// <summary>
+    /// Whether to block suspicious unknown behavior that may still be a false positive.
+    /// </summary>
+    public bool BlockSuspicious { get; set; } = true;
+
+    /// <summary>
+    /// Legacy severity threshold from the rule-first blocking model.
+    /// Retained for one compatibility window but no longer used for blocking decisions.
     /// </summary>
     public Severity MinSeverityForDisable { get; set; } = Severity.Medium;
 
@@ -36,7 +47,8 @@ public class MLVScanConfig
     public string[] ScanDirectories { get; set; } = ["Mods", "Plugins"];
 
     /// <summary>
-    /// How many suspicious findings before disabling a mod.
+    /// Legacy suspicious threshold from the rule-first blocking model.
+    /// Retained for one compatibility window but no longer used for blocking decisions.
     /// </summary>
     public int SuspiciousThreshold { get; set; } = 1;
 
@@ -69,6 +81,12 @@ public class MLVScanConfig
     /// Path to the first suspicious mod awaiting consent for upload.
     /// </summary>
     public string PendingReportUploadPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Threat verdict kind for the pending upload item.
+    /// Used to show verdict-specific consent messaging.
+    /// </summary>
+    public string PendingReportUploadVerdictKind { get; set; } = string.Empty;
 
     /// <summary>
     /// API base URL for report uploads.

--- a/Models/ThreatVerdictInfo.cs
+++ b/Models/ThreatVerdictInfo.cs
@@ -34,6 +34,16 @@ namespace MLVScan.Models
     }
 
     /// <summary>
+    /// User-facing scan completion status for a scan result.
+    /// </summary>
+    public class ScanStatusInfo
+    {
+        public ScanStatusKind Kind { get; set; } = ScanStatusKind.Complete;
+        public string Title { get; set; } = string.Empty;
+        public string Summary { get; set; } = string.Empty;
+    }
+
+    /// <summary>
     /// Full scan result for a single mod or plugin file.
     /// </summary>
     public class ScannedPluginResult
@@ -42,5 +52,29 @@ namespace MLVScan.Models
         public string FileHash { get; set; } = string.Empty;
         public List<ScanFinding> Findings { get; set; } = new List<ScanFinding>();
         public ThreatVerdictInfo ThreatVerdict { get; set; } = new ThreatVerdictInfo();
+        public ScanStatusInfo ScanStatus { get; set; } = new ScanStatusInfo();
+    }
+
+    internal static class ScanResultFacts
+    {
+        public static bool HasThreatVerdict(ScannedPluginResult result)
+        {
+            return (result?.ThreatVerdict?.Kind ?? ThreatVerdictKind.None) != ThreatVerdictKind.None;
+        }
+
+        public static bool RequiresManualReview(ScannedPluginResult result)
+        {
+            return (result?.ScanStatus?.Kind ?? ScanStatusKind.Complete) != ScanStatusKind.Complete;
+        }
+
+        public static bool RequiresAttention(ScannedPluginResult result)
+        {
+            return HasThreatVerdict(result) || RequiresManualReview(result);
+        }
+
+        public static bool IsClean(ScannedPluginResult result)
+        {
+            return !RequiresAttention(result);
+        }
     }
 }

--- a/Models/ThreatVerdictKind.cs
+++ b/Models/ThreatVerdictKind.cs
@@ -10,4 +10,13 @@ namespace MLVScan.Models
         KnownMalwareFamily,
         KnownMaliciousSample
     }
+
+    /// <summary>
+    /// User-facing scan completion status, independent of the threat verdict.
+    /// </summary>
+    public enum ScanStatusKind
+    {
+        Complete,
+        RequiresReview
+    }
 }

--- a/PlatformConstants.cs
+++ b/PlatformConstants.cs
@@ -47,6 +47,6 @@ namespace MLVScan
         /// Gets the combined version info including core engine.
         /// </summary>
         public static string GetFullVersionInfo() =>
-            $"Engine: {Constants.GetVersionString()}\nPlatform: {GetVersionString()}";
+            $"Engine: MLVScan.Core v{MLVScanVersions.CoreVersion}\nPlatform: {GetVersionString()}";
     }
 }

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Supports **MelonLoader**, **BepInEx 5.x**, and **BepInEx 6.x** (Mono & Il2Cpp).
 2. **Install** by dropping it into your game's `BepInEx/plugins` folder.
 3. **Play!** MLVScan automatically scans plugins before they load.
 
+## Blocking Policy
+
+MLVScan now separates **threat verdicts** from **scan completeness**:
+
+- `BlockKnownThreats = true` blocks exact malicious sample matches and known malware-family matches.
+- `BlockSuspicious = true` blocks unknown correlated suspicious behavior that may still be a false positive.
+- `BlockIncompleteScans = false` leaves incomplete scans as **manual review required** by default instead of blocking them automatically.
+
+Current loader note: assemblies larger than **256 MB** are still SHA256 hashed and checked for exact known-malicious sample matches, but full IL analysis is skipped to avoid loading the entire file into memory during startup. Those files are reported as manual-review items unless you explicitly enable `BlockIncompleteScans`.
+
 ## Optional Report Upload
 
 MLVScan can optionally send scan reports to the MLVScan API to help fix false positives. This is **off by default** and requires your explicit consent.
@@ -39,7 +49,7 @@ MLVScan can optionally send scan reports to the MLVScan API to help fix false po
 - **MelonLoader:** Set `EnableReportUpload = true` in `MelonPreferences.cfg` under `[MLVScan]`
 - **BepInEx:** Set `"EnableReportUpload": true` in `BepInEx/config/MLVScan.json`
 
-The first time a suspicious mod is detected, MLVScan shows a one-time message. Local reports are always generated regardless of upload settings.
+The first time a suspicious or known-malicious mod is detected, MLVScan shows a one-time message. Local reports are always generated regardless of upload settings.
 
 ## 📚 Documentation
 

--- a/Services/Caching/AtomicFileStorage.cs
+++ b/Services/Caching/AtomicFileStorage.cs
@@ -19,7 +19,26 @@ namespace MLVScan.Services.Caching
                 stream.Flush(true);
             }
 
-            Replace(tempPath, path);
+            try
+            {
+                Replace(tempPath, path);
+            }
+            catch
+            {
+                if (File.Exists(tempPath))
+                {
+                    try
+                    {
+                        File.Delete(tempPath);
+                    }
+                    catch
+                    {
+                        // Preserve the original replace failure if cleanup also fails.
+                    }
+                }
+
+                throw;
+            }
         }
 
         public static void WriteAllText(string path, string contents)

--- a/Services/Caching/AtomicFileStorage.cs
+++ b/Services/Caching/AtomicFileStorage.cs
@@ -1,0 +1,41 @@
+using System.IO;
+
+namespace MLVScan.Services.Caching
+{
+    internal static class AtomicFileStorage
+    {
+        public static void WriteAllBytes(string path, byte[] contents)
+        {
+            var directory = Path.GetDirectoryName(path);
+            if (!string.IsNullOrWhiteSpace(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            var tempPath = path + ".tmp";
+            using (var stream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                stream.Write(contents, 0, contents.Length);
+                stream.Flush(true);
+            }
+
+            Replace(tempPath, path);
+        }
+
+        public static void WriteAllText(string path, string contents)
+        {
+            WriteAllBytes(path, System.Text.Encoding.UTF8.GetBytes(contents));
+        }
+
+        private static void Replace(string tempPath, string path)
+        {
+            if (File.Exists(path))
+            {
+                File.Replace(tempPath, path, null, true);
+                return;
+            }
+
+            File.Move(tempPath, path);
+        }
+    }
+}

--- a/Services/Caching/CrossPlatformFileIdentityProvider.cs
+++ b/Services/Caching/CrossPlatformFileIdentityProvider.cs
@@ -57,18 +57,32 @@ namespace MLVScan.Services.Caching
             if (RuntimeInformationHelper.IsWindows)
             {
                 var builder = new StringBuilder(1024);
-                var result = GetFinalPathNameByHandle(handle, builder, builder.Capacity, 0);
-                if (result > 0)
+                while (true)
                 {
-                    return NormalizeWindowsDevicePath(builder.ToString());
-                }
+                    var result = GetFinalPathNameByHandle(handle, builder, builder.Capacity, 0);
+                    if (result == 0)
+                    {
+                        return path;
+                    }
 
-                return path;
+                    if (result >= builder.Capacity)
+                    {
+                        if (result >= int.MaxValue)
+                        {
+                            return path;
+                        }
+
+                        builder = new StringBuilder((int)result + 1);
+                        continue;
+                    }
+
+                    return NormalizeWindowsDevicePath(builder.ToString(0, (int)result));
+                }
             }
 
             try
             {
-                var realPath = UnixPath.GetRealPath(path);
+                var realPath = GetUnixCanonicalPath(handle, path);
                 return string.IsNullOrWhiteSpace(realPath)
                     ? path
                     : Path.GetFullPath(realPath);
@@ -139,6 +153,19 @@ namespace MLVScan.Services.Caching
             }
 
             return (int)rawHandle;
+        }
+
+        private static string GetUnixCanonicalPath(SafeFileHandle handle, string path)
+        {
+            var fd = GetUnixFileDescriptor(handle, path);
+            var descriptorPath = RuntimeInformationHelper.IsLinux
+                ? $"/proc/self/fd/{fd}"
+                : $"/dev/fd/{fd}";
+
+            var realPath = UnixPath.GetRealPath(descriptorPath);
+            return string.IsNullOrWhiteSpace(realPath)
+                ? path
+                : realPath;
         }
 
         private static string NormalizeWindowsDevicePath(string path)

--- a/Services/Caching/CrossPlatformFileIdentityProvider.cs
+++ b/Services/Caching/CrossPlatformFileIdentityProvider.cs
@@ -105,7 +105,7 @@ namespace MLVScan.Services.Caching
 
         private static FileIdentitySnapshot CreateUnixIdentity(string path, SafeFileHandle handle, bool isLink)
         {
-            var fd = handle.DangerousGetHandle().ToInt32();
+            var fd = GetUnixFileDescriptor(handle, path);
             if (Syscall.fstat(fd, out var stat) != 0)
             {
                 throw new IOException($"fstat failed for {path}");
@@ -117,10 +117,28 @@ namespace MLVScan.Services.Caching
                 HasStrongIdentity = true,
                 IdentityKey = $"{stat.st_dev}:{stat.st_ino}",
                 Size = stat.st_size,
-                LastWriteUtcTicks = DateTimeOffset.FromUnixTimeSeconds(stat.st_mtime).UtcDateTime.Ticks,
-                ChangeUtcTicks = DateTimeOffset.FromUnixTimeSeconds(stat.st_ctime).UtcDateTime.Ticks,
+                LastWriteUtcTicks = ConvertUnixTimeToUtcTicks(stat.st_mtime, stat.st_mtime_nsec),
+                ChangeUtcTicks = ConvertUnixTimeToUtcTicks(stat.st_ctime, stat.st_ctime_nsec),
                 IsSymlinkOrReparsePoint = isLink
             };
+        }
+
+        private static long ConvertUnixTimeToUtcTicks(long seconds, long nanoseconds)
+        {
+            return checked(DateTime.UnixEpoch.Ticks +
+                (seconds * TimeSpan.TicksPerSecond) +
+                (nanoseconds / 100));
+        }
+
+        private static int GetUnixFileDescriptor(SafeFileHandle handle, string path)
+        {
+            var rawHandle = handle.DangerousGetHandle().ToInt64();
+            if (rawHandle < 0 || rawHandle > int.MaxValue)
+            {
+                throw new IOException($"File descriptor out of range for {path}");
+            }
+
+            return (int)rawHandle;
         }
 
         private static string NormalizeWindowsDevicePath(string path)

--- a/Services/Caching/CrossPlatformFileIdentityProvider.cs
+++ b/Services/Caching/CrossPlatformFileIdentityProvider.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
-using Mono.Unix;
-using Mono.Unix.Native;
 
 namespace MLVScan.Services.Caching
 {
@@ -39,57 +37,44 @@ namespace MLVScan.Services.Caching
 
         private static bool IsSymlinkOrReparsePoint(string path)
         {
-            if (RuntimeInformationHelper.IsWindows)
+            try
             {
                 return File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
             }
-
-            if (Syscall.lstat(path, out var stat) != 0)
+            catch
             {
                 return false;
             }
-
-            return (stat.st_mode & FilePermissions.S_IFMT) == FilePermissions.S_IFLNK;
         }
 
         private static string GetCanonicalPath(string path, SafeFileHandle handle)
         {
-            if (RuntimeInformationHelper.IsWindows)
+            if (!RuntimeInformationHelper.IsWindows)
             {
-                var builder = new StringBuilder(1024);
-                while (true)
+                return path;
+            }
+
+            var builder = new StringBuilder(1024);
+            while (true)
+            {
+                var result = GetFinalPathNameByHandle(handle, builder, builder.Capacity, 0);
+                if (result == 0)
                 {
-                    var result = GetFinalPathNameByHandle(handle, builder, builder.Capacity, 0);
-                    if (result == 0)
+                    return path;
+                }
+
+                if (result >= builder.Capacity)
+                {
+                    if (result >= int.MaxValue)
                     {
                         return path;
                     }
 
-                    if (result >= builder.Capacity)
-                    {
-                        if (result >= int.MaxValue)
-                        {
-                            return path;
-                        }
-
-                        builder = new StringBuilder((int)result + 1);
-                        continue;
-                    }
-
-                    return NormalizeWindowsDevicePath(builder.ToString(0, (int)result));
+                    builder = new StringBuilder((int)result + 1);
+                    continue;
                 }
-            }
 
-            try
-            {
-                var realPath = GetUnixCanonicalPath(handle, path);
-                return string.IsNullOrWhiteSpace(realPath)
-                    ? path
-                    : Path.GetFullPath(realPath);
-            }
-            catch
-            {
-                return path;
+                return NormalizeWindowsDevicePath(builder.ToString(0, (int)result));
             }
         }
 
@@ -119,53 +104,23 @@ namespace MLVScan.Services.Caching
 
         private static FileIdentitySnapshot CreateUnixIdentity(string path, SafeFileHandle handle, bool isLink)
         {
-            var fd = GetUnixFileDescriptor(handle, path);
-            if (Syscall.fstat(fd, out var stat) != 0)
-            {
-                throw new IOException($"fstat failed for {path}");
-            }
+            _ = handle;
+
+            var info = new FileInfo(path);
+            var lastWriteUtcTicks = info.LastWriteTimeUtc.Ticks;
 
             return new FileIdentitySnapshot
             {
                 Platform = RuntimeInformationHelper.IsMacOs ? "macos" : "linux",
-                HasStrongIdentity = true,
-                IdentityKey = $"{stat.st_dev}:{stat.st_ino}",
-                Size = stat.st_size,
-                LastWriteUtcTicks = ConvertUnixTimeToUtcTicks(stat.st_mtime, stat.st_mtime_nsec),
-                ChangeUtcTicks = ConvertUnixTimeToUtcTicks(stat.st_ctime, stat.st_ctime_nsec),
+                // Keep Unix cache reuse on the hash path only so shared loader builds
+                // do not need native helper assemblies just to read inode metadata.
+                HasStrongIdentity = false,
+                IdentityKey = Path.GetFullPath(path),
+                Size = info.Exists ? info.Length : 0L,
+                LastWriteUtcTicks = lastWriteUtcTicks,
+                ChangeUtcTicks = lastWriteUtcTicks,
                 IsSymlinkOrReparsePoint = isLink
             };
-        }
-
-        private static long ConvertUnixTimeToUtcTicks(long seconds, long nanoseconds)
-        {
-            return checked(DateTime.UnixEpoch.Ticks +
-                (seconds * TimeSpan.TicksPerSecond) +
-                (nanoseconds / 100));
-        }
-
-        private static int GetUnixFileDescriptor(SafeFileHandle handle, string path)
-        {
-            var rawHandle = handle.DangerousGetHandle().ToInt64();
-            if (rawHandle < 0 || rawHandle > int.MaxValue)
-            {
-                throw new IOException($"File descriptor out of range for {path}");
-            }
-
-            return (int)rawHandle;
-        }
-
-        private static string GetUnixCanonicalPath(SafeFileHandle handle, string path)
-        {
-            var fd = GetUnixFileDescriptor(handle, path);
-            var descriptorPath = RuntimeInformationHelper.IsLinux
-                ? $"/proc/self/fd/{fd}"
-                : $"/dev/fd/{fd}";
-
-            var realPath = UnixPath.GetRealPath(descriptorPath);
-            return string.IsNullOrWhiteSpace(realPath)
-                ? path
-                : realPath;
         }
 
         private static string NormalizeWindowsDevicePath(string path)

--- a/Services/Caching/CrossPlatformFileIdentityProvider.cs
+++ b/Services/Caching/CrossPlatformFileIdentityProvider.cs
@@ -1,0 +1,175 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
+using Mono.Unix;
+using Mono.Unix.Native;
+
+namespace MLVScan.Services.Caching
+{
+    internal sealed class CrossPlatformFileIdentityProvider : IFileIdentityProvider
+    {
+        public FileProbe OpenProbe(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                throw new ArgumentException("Path is required.", nameof(path));
+            }
+
+            var fullPath = Path.GetFullPath(path);
+            var isLink = IsSymlinkOrReparsePoint(fullPath);
+            var stream = new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+
+            try
+            {
+                var canonicalPath = GetCanonicalPath(fullPath, stream.SafeFileHandle);
+                var identity = RuntimeInformationHelper.IsWindows
+                    ? CreateWindowsIdentity(fullPath, stream.SafeFileHandle, isLink)
+                    : CreateUnixIdentity(fullPath, stream.SafeFileHandle, isLink);
+
+                return new FileProbe(fullPath, canonicalPath, stream, identity, isLink);
+            }
+            catch
+            {
+                stream.Dispose();
+                throw;
+            }
+        }
+
+        private static bool IsSymlinkOrReparsePoint(string path)
+        {
+            if (RuntimeInformationHelper.IsWindows)
+            {
+                return File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+            }
+
+            if (Syscall.lstat(path, out var stat) != 0)
+            {
+                return false;
+            }
+
+            return (stat.st_mode & FilePermissions.S_IFMT) == FilePermissions.S_IFLNK;
+        }
+
+        private static string GetCanonicalPath(string path, SafeFileHandle handle)
+        {
+            if (RuntimeInformationHelper.IsWindows)
+            {
+                var builder = new StringBuilder(1024);
+                var result = GetFinalPathNameByHandle(handle, builder, builder.Capacity, 0);
+                if (result > 0)
+                {
+                    return NormalizeWindowsDevicePath(builder.ToString());
+                }
+
+                return path;
+            }
+
+            try
+            {
+                var realPath = UnixPath.GetRealPath(path);
+                return string.IsNullOrWhiteSpace(realPath)
+                    ? path
+                    : Path.GetFullPath(realPath);
+            }
+            catch
+            {
+                return path;
+            }
+        }
+
+        private static FileIdentitySnapshot CreateWindowsIdentity(string path, SafeFileHandle handle, bool isLink)
+        {
+            if (!GetFileInformationByHandle(handle, out var info))
+            {
+                throw new IOException($"GetFileInformationByHandle failed for {path}");
+            }
+
+            var lastWriteUtcTicks = DateTime.FromFileTimeUtc((((long)info.ftLastWriteTime.dwHighDateTime) << 32) |
+                (uint)info.ftLastWriteTime.dwLowDateTime).Ticks;
+            var size = (((long)info.nFileSizeHigh) << 32) | (uint)info.nFileSizeLow;
+            var fileId = $"{info.dwVolumeSerialNumber:x8}:{info.nFileIndexHigh:x8}{info.nFileIndexLow:x8}";
+
+            return new FileIdentitySnapshot
+            {
+                Platform = "windows",
+                HasStrongIdentity = true,
+                IdentityKey = fileId,
+                Size = size,
+                LastWriteUtcTicks = lastWriteUtcTicks,
+                ChangeUtcTicks = lastWriteUtcTicks,
+                IsSymlinkOrReparsePoint = isLink
+            };
+        }
+
+        private static FileIdentitySnapshot CreateUnixIdentity(string path, SafeFileHandle handle, bool isLink)
+        {
+            var fd = handle.DangerousGetHandle().ToInt32();
+            if (Syscall.fstat(fd, out var stat) != 0)
+            {
+                throw new IOException($"fstat failed for {path}");
+            }
+
+            return new FileIdentitySnapshot
+            {
+                Platform = RuntimeInformationHelper.IsMacOs ? "macos" : "linux",
+                HasStrongIdentity = true,
+                IdentityKey = $"{stat.st_dev}:{stat.st_ino}",
+                Size = stat.st_size,
+                LastWriteUtcTicks = DateTimeOffset.FromUnixTimeSeconds(stat.st_mtime).UtcDateTime.Ticks,
+                ChangeUtcTicks = DateTimeOffset.FromUnixTimeSeconds(stat.st_ctime).UtcDateTime.Ticks,
+                IsSymlinkOrReparsePoint = isLink
+            };
+        }
+
+        private static string NormalizeWindowsDevicePath(string path)
+        {
+            if (path.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+            {
+                return @"\\" + path.Substring(8);
+            }
+
+            if (path.StartsWith(@"\\?\", StringComparison.OrdinalIgnoreCase))
+            {
+                return path.Substring(4);
+            }
+
+            return path;
+        }
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern uint GetFinalPathNameByHandle(
+            SafeFileHandle hFile,
+            StringBuilder lpszFilePath,
+            int cchFilePath,
+            uint dwFlags);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetFileInformationByHandle(
+            SafeFileHandle hFile,
+            out ByHandleFileInformation lpFileInformation);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct ByHandleFileInformation
+        {
+            public uint dwFileAttributes;
+            public FileTime ftCreationTime;
+            public FileTime ftLastAccessTime;
+            public FileTime ftLastWriteTime;
+            public uint dwVolumeSerialNumber;
+            public uint nFileSizeHigh;
+            public uint nFileSizeLow;
+            public uint nNumberOfLinks;
+            public uint nFileIndexHigh;
+            public uint nFileIndexLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct FileTime
+        {
+            public uint dwLowDateTime;
+            public uint dwHighDateTime;
+        }
+    }
+}

--- a/Services/Caching/IFileIdentityProvider.cs
+++ b/Services/Caching/IFileIdentityProvider.cs
@@ -1,0 +1,79 @@
+using System.IO;
+
+namespace MLVScan.Services.Caching
+{
+    internal interface IFileIdentityProvider
+    {
+        FileProbe OpenProbe(string path);
+    }
+
+    internal sealed class FileProbe : IDisposable
+    {
+        public FileProbe(
+            string originalPath,
+            string canonicalPath,
+            FileStream stream,
+            FileIdentitySnapshot identity,
+            bool isSymlinkOrReparsePoint)
+        {
+            OriginalPath = originalPath;
+            CanonicalPath = canonicalPath;
+            Stream = stream;
+            Identity = identity;
+            IsSymlinkOrReparsePoint = isSymlinkOrReparsePoint;
+        }
+
+        public string OriginalPath { get; }
+
+        public string CanonicalPath { get; }
+
+        public FileStream Stream { get; }
+
+        public FileIdentitySnapshot Identity { get; }
+
+        public bool IsSymlinkOrReparsePoint { get; }
+
+        public bool CanReuseByStrongIdentity =>
+            !IsSymlinkOrReparsePoint &&
+            Identity.HasStrongIdentity;
+
+        public void Dispose()
+        {
+            Stream.Dispose();
+        }
+    }
+
+    internal sealed class FileIdentitySnapshot
+    {
+        public string Platform { get; set; } = string.Empty;
+
+        public bool HasStrongIdentity { get; set; }
+
+        public string IdentityKey { get; set; } = string.Empty;
+
+        public long Size { get; set; }
+
+        public long LastWriteUtcTicks { get; set; }
+
+        public long ChangeUtcTicks { get; set; }
+
+        public bool IsSymlinkOrReparsePoint { get; set; }
+
+        public bool MatchesStrongIdentity(FileIdentitySnapshot other)
+        {
+            if (other == null ||
+                !HasStrongIdentity ||
+                !other.HasStrongIdentity)
+            {
+                return false;
+            }
+
+            return string.Equals(Platform, other.Platform, System.StringComparison.Ordinal) &&
+                   string.Equals(IdentityKey, other.IdentityKey, System.StringComparison.Ordinal) &&
+                   Size == other.Size &&
+                   LastWriteUtcTicks == other.LastWriteUtcTicks &&
+                   ChangeUtcTicks == other.ChangeUtcTicks &&
+                   IsSymlinkOrReparsePoint == other.IsSymlinkOrReparsePoint;
+        }
+    }
+}

--- a/Services/Caching/IScanCacheSigner.cs
+++ b/Services/Caching/IScanCacheSigner.cs
@@ -1,0 +1,11 @@
+namespace MLVScan.Services.Caching
+{
+    internal interface IScanCacheSigner
+    {
+        bool CanTrustCleanEntries { get; }
+
+        string Sign(string payloadJson);
+
+        bool Verify(string payloadJson, string signature);
+    }
+}

--- a/Services/Caching/IScanCacheSigner.cs
+++ b/Services/Caching/IScanCacheSigner.cs
@@ -4,8 +4,8 @@ namespace MLVScan.Services.Caching
     {
         bool CanTrustCleanEntries { get; }
 
-        string Sign(string payloadJson);
+        string Sign(byte[] payloadBytes);
 
-        bool Verify(string payloadJson, string signature);
+        bool Verify(byte[] payloadBytes, string signature);
     }
 }

--- a/Services/Caching/IScanCacheStore.cs
+++ b/Services/Caching/IScanCacheStore.cs
@@ -1,0 +1,17 @@
+namespace MLVScan.Services.Caching
+{
+    internal interface IScanCacheStore
+    {
+        bool CanTrustCleanEntries { get; }
+
+        ScanCacheEntry TryGetByPath(string canonicalPath);
+
+        ScanCacheEntry TryGetByHash(string sha256Hash);
+
+        void Upsert(ScanCacheEntry entry);
+
+        void Remove(string canonicalPath);
+
+        void PruneMissingEntries(System.Collections.Generic.IReadOnlyCollection<string> activeCanonicalPaths);
+    }
+}

--- a/Services/Caching/RuntimeInformationHelper.cs
+++ b/Services/Caching/RuntimeInformationHelper.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace MLVScan.Services.Caching
+{
+    internal static class RuntimeInformationHelper
+    {
+        public static bool IsWindows => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        public static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+        public static bool IsMacOs => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+    }
+}

--- a/Services/Caching/ScanCacheEnvelopeCodec.cs
+++ b/Services/Caching/ScanCacheEnvelopeCodec.cs
@@ -1,0 +1,515 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using MLVScan.Models;
+
+namespace MLVScan.Services.Caching
+{
+    internal static class ScanCacheEnvelopeCodec
+    {
+        private const int EnvelopeMagic = 0x4D4C5643;
+        private const int EnvelopeVersion = 1;
+
+        public static byte[] SerializePayload(ScanCacheEntryPayload payload)
+        {
+            using var memory = new MemoryStream();
+            using var writer = new BinaryWriter(memory, Encoding.UTF8, true);
+            WritePayload(writer, payload ?? new ScanCacheEntryPayload());
+            writer.Flush();
+            return memory.ToArray();
+        }
+
+        public static byte[] SerializeEnvelope(string signature, byte[] payloadBytes)
+        {
+            var bytes = payloadBytes ?? Array.Empty<byte>();
+
+            using var memory = new MemoryStream();
+            using var writer = new BinaryWriter(memory, Encoding.UTF8, true);
+            writer.Write(EnvelopeMagic);
+            writer.Write(EnvelopeVersion);
+            WriteString(writer, signature);
+            writer.Write(bytes.Length);
+            writer.Write(bytes);
+            writer.Flush();
+            return memory.ToArray();
+        }
+
+        public static bool TryDeserializeEnvelope(
+            byte[] envelopeBytes,
+            out string signature,
+            out byte[] payloadBytes,
+            out ScanCacheEntryPayload payload)
+        {
+            signature = string.Empty;
+            payloadBytes = Array.Empty<byte>();
+            payload = null;
+
+            if (envelopeBytes == null || envelopeBytes.Length == 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                using var memory = new MemoryStream(envelopeBytes, writable: false);
+                using var reader = new BinaryReader(memory, Encoding.UTF8, true);
+
+                if (reader.ReadInt32() != EnvelopeMagic || reader.ReadInt32() != EnvelopeVersion)
+                {
+                    return false;
+                }
+
+                signature = ReadString(reader);
+                var payloadLength = reader.ReadInt32();
+                if (payloadLength < 0 || payloadLength > (memory.Length - memory.Position))
+                {
+                    return false;
+                }
+
+                payloadBytes = reader.ReadBytes(payloadLength);
+                if (payloadBytes.Length != payloadLength)
+                {
+                    return false;
+                }
+
+                payload = DeserializePayload(payloadBytes);
+                return payload != null;
+            }
+            catch
+            {
+                signature = string.Empty;
+                payloadBytes = Array.Empty<byte>();
+                payload = null;
+                return false;
+            }
+        }
+
+        private static ScanCacheEntryPayload DeserializePayload(byte[] payloadBytes)
+        {
+            using var memory = new MemoryStream(payloadBytes, writable: false);
+            using var reader = new BinaryReader(memory, Encoding.UTF8, true);
+
+            return new ScanCacheEntryPayload
+            {
+                CanonicalPath = ReadString(reader),
+                RealPath = ReadString(reader),
+                FileIdentity = ReadFileIdentity(reader),
+                Sha256 = ReadString(reader),
+                ScannerFingerprint = ReadString(reader),
+                ResolverFingerprint = ReadString(reader),
+                CreatedUtc = DateTime.FromBinary(reader.ReadInt64()),
+                VerifiedUtc = DateTime.FromBinary(reader.ReadInt64()),
+                Result = ReadResult(reader)
+            };
+        }
+
+        private static void WritePayload(BinaryWriter writer, ScanCacheEntryPayload payload)
+        {
+            WriteString(writer, payload.CanonicalPath);
+            WriteString(writer, payload.RealPath);
+            WriteFileIdentity(writer, payload.FileIdentity);
+            WriteString(writer, payload.Sha256);
+            WriteString(writer, payload.ScannerFingerprint);
+            WriteString(writer, payload.ResolverFingerprint);
+            writer.Write(payload.CreatedUtc.ToBinary());
+            writer.Write(payload.VerifiedUtc.ToBinary());
+            WriteResult(writer, payload.Result);
+        }
+
+        private static void WriteFileIdentity(BinaryWriter writer, FileIdentitySnapshot identity)
+        {
+            var value = identity ?? new FileIdentitySnapshot();
+            WriteString(writer, value.Platform);
+            writer.Write(value.HasStrongIdentity);
+            WriteString(writer, value.IdentityKey);
+            writer.Write(value.Size);
+            writer.Write(value.LastWriteUtcTicks);
+            writer.Write(value.ChangeUtcTicks);
+            writer.Write(value.IsSymlinkOrReparsePoint);
+        }
+
+        private static FileIdentitySnapshot ReadFileIdentity(BinaryReader reader)
+        {
+            return new FileIdentitySnapshot
+            {
+                Platform = ReadString(reader),
+                HasStrongIdentity = reader.ReadBoolean(),
+                IdentityKey = ReadString(reader),
+                Size = reader.ReadInt64(),
+                LastWriteUtcTicks = reader.ReadInt64(),
+                ChangeUtcTicks = reader.ReadInt64(),
+                IsSymlinkOrReparsePoint = reader.ReadBoolean()
+            };
+        }
+
+        private static void WriteResult(BinaryWriter writer, ScannedPluginResult result)
+        {
+            var value = result ?? new ScannedPluginResult();
+            WriteString(writer, value.FilePath);
+            WriteString(writer, value.FileHash);
+            WriteFindings(writer, value.Findings);
+            WriteThreatVerdict(writer, value.ThreatVerdict);
+        }
+
+        private static ScannedPluginResult ReadResult(BinaryReader reader)
+        {
+            return new ScannedPluginResult
+            {
+                FilePath = ReadString(reader),
+                FileHash = ReadString(reader),
+                Findings = ReadFindings(reader),
+                ThreatVerdict = ReadThreatVerdict(reader) ?? new ThreatVerdictInfo()
+            };
+        }
+
+        private static void WriteFindings(BinaryWriter writer, List<ScanFinding> findings)
+        {
+            var values = findings ?? new List<ScanFinding>();
+            writer.Write(values.Count);
+            foreach (var finding in values)
+            {
+                WriteFinding(writer, finding);
+            }
+        }
+
+        private static List<ScanFinding> ReadFindings(BinaryReader reader)
+        {
+            var count = reader.ReadInt32();
+            var findings = new List<ScanFinding>(Math.Max(count, 0));
+            for (var i = 0; i < count; i++)
+            {
+                findings.Add(ReadFinding(reader));
+            }
+
+            return findings;
+        }
+
+        private static void WriteFinding(BinaryWriter writer, ScanFinding finding)
+        {
+            var value = finding ?? new ScanFinding(string.Empty, string.Empty);
+            WriteString(writer, value.Location);
+            WriteString(writer, value.Description);
+            writer.Write((int)value.Severity);
+            WriteString(writer, value.CodeSnippet);
+            WriteString(writer, value.RuleId);
+            writer.Write(value.BypassCompanionCheck);
+            writer.Write(value.RiskScore.HasValue);
+            if (value.RiskScore.HasValue)
+            {
+                writer.Write(value.RiskScore.Value);
+            }
+
+            WriteCallChain(writer, value.CallChain);
+            WriteDataFlowChain(writer, value.DataFlowChain);
+        }
+
+        private static ScanFinding ReadFinding(BinaryReader reader)
+        {
+            var finding = new ScanFinding(
+                ReadString(reader),
+                ReadString(reader),
+                (Severity)reader.ReadInt32(),
+                ReadString(reader))
+            {
+                RuleId = ReadString(reader),
+                BypassCompanionCheck = reader.ReadBoolean()
+            };
+
+            if (reader.ReadBoolean())
+            {
+                finding.RiskScore = reader.ReadInt32();
+            }
+
+            finding.CallChain = ReadCallChain(reader);
+            finding.DataFlowChain = ReadDataFlowChain(reader);
+            return finding;
+        }
+
+        private static void WriteThreatVerdict(BinaryWriter writer, ThreatVerdictInfo verdict)
+        {
+            writer.Write(verdict != null);
+            if (verdict == null)
+            {
+                return;
+            }
+
+            writer.Write((int)verdict.Kind);
+            WriteString(writer, verdict.Title);
+            WriteString(writer, verdict.Summary);
+            writer.Write(verdict.Confidence);
+            writer.Write(verdict.ShouldBypassThreshold);
+            WriteThreatFamily(writer, verdict.PrimaryFamily);
+            WriteThreatFamilies(writer, verdict.Families);
+        }
+
+        private static ThreatVerdictInfo ReadThreatVerdict(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            return new ThreatVerdictInfo
+            {
+                Kind = (ThreatVerdictKind)reader.ReadInt32(),
+                Title = ReadString(reader),
+                Summary = ReadString(reader),
+                Confidence = reader.ReadDouble(),
+                ShouldBypassThreshold = reader.ReadBoolean(),
+                PrimaryFamily = ReadThreatFamily(reader),
+                Families = ReadThreatFamilies(reader)
+            };
+        }
+
+        private static void WriteThreatFamilies(BinaryWriter writer, List<ThreatFamilyReference> families)
+        {
+            var values = families ?? new List<ThreatFamilyReference>();
+            writer.Write(values.Count);
+            foreach (var family in values)
+            {
+                WriteThreatFamily(writer, family);
+            }
+        }
+
+        private static List<ThreatFamilyReference> ReadThreatFamilies(BinaryReader reader)
+        {
+            var count = reader.ReadInt32();
+            var families = new List<ThreatFamilyReference>(Math.Max(count, 0));
+            for (var i = 0; i < count; i++)
+            {
+                families.Add(ReadThreatFamily(reader));
+            }
+
+            return families;
+        }
+
+        private static void WriteThreatFamily(BinaryWriter writer, ThreatFamilyReference family)
+        {
+            writer.Write(family != null);
+            if (family == null)
+            {
+                return;
+            }
+
+            WriteString(writer, family.FamilyId);
+            WriteString(writer, family.DisplayName);
+            WriteString(writer, family.Summary);
+            WriteString(writer, family.MatchKind);
+            WriteString(writer, family.TechnicalName);
+            WriteString(writer, family.ReferenceUrl);
+            writer.Write(family.Confidence);
+            writer.Write(family.ExactHashMatch);
+            WriteStringList(writer, family.MatchedRules);
+            WriteStringList(writer, family.Evidence);
+        }
+
+        private static ThreatFamilyReference ReadThreatFamily(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            return new ThreatFamilyReference
+            {
+                FamilyId = ReadString(reader),
+                DisplayName = ReadString(reader),
+                Summary = ReadString(reader),
+                MatchKind = ReadString(reader),
+                TechnicalName = ReadString(reader),
+                ReferenceUrl = ReadString(reader),
+                Confidence = reader.ReadDouble(),
+                ExactHashMatch = reader.ReadBoolean(),
+                MatchedRules = ReadStringList(reader),
+                Evidence = ReadStringList(reader)
+            };
+        }
+
+        private static void WriteCallChain(BinaryWriter writer, CallChain callChain)
+        {
+            writer.Write(callChain != null);
+            if (callChain == null)
+            {
+                return;
+            }
+
+            WriteString(writer, callChain.ChainId);
+            WriteString(writer, callChain.RuleId);
+            writer.Write((int)callChain.Severity);
+            WriteString(writer, callChain.Summary);
+            writer.Write(callChain.Nodes?.Count ?? 0);
+            if (callChain.Nodes != null)
+            {
+                foreach (var node in callChain.Nodes)
+                {
+                    WriteCallChainNode(writer, node);
+                }
+            }
+        }
+
+        private static CallChain ReadCallChain(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            var callChain = new CallChain(
+                ReadString(reader),
+                ReadString(reader),
+                (Severity)reader.ReadInt32(),
+                ReadString(reader));
+
+            var nodeCount = reader.ReadInt32();
+            for (var i = 0; i < nodeCount; i++)
+            {
+                callChain.AppendNode(ReadCallChainNode(reader));
+            }
+
+            return callChain;
+        }
+
+        private static void WriteCallChainNode(BinaryWriter writer, CallChainNode node)
+        {
+            var value = node ?? new CallChainNode(string.Empty, string.Empty, CallChainNodeType.IntermediateCall);
+            WriteString(writer, value.Location);
+            WriteString(writer, value.Description);
+            writer.Write((int)value.NodeType);
+            WriteString(writer, value.CodeSnippet);
+        }
+
+        private static CallChainNode ReadCallChainNode(BinaryReader reader)
+        {
+            return new CallChainNode(
+                ReadString(reader),
+                ReadString(reader),
+                (CallChainNodeType)reader.ReadInt32(),
+                ReadString(reader));
+        }
+
+        private static void WriteDataFlowChain(BinaryWriter writer, DataFlowChain dataFlowChain)
+        {
+            writer.Write(dataFlowChain != null);
+            if (dataFlowChain == null)
+            {
+                return;
+            }
+
+            WriteString(writer, dataFlowChain.ChainId);
+            WriteString(writer, dataFlowChain.SourceVariable);
+            writer.Write((int)dataFlowChain.Pattern);
+            writer.Write((int)dataFlowChain.Severity);
+            WriteString(writer, dataFlowChain.Summary);
+            WriteString(writer, dataFlowChain.MethodLocation);
+            writer.Write(dataFlowChain.IsCrossMethod);
+            WriteStringList(writer, dataFlowChain.InvolvedMethods);
+            writer.Write(dataFlowChain.Nodes?.Count ?? 0);
+            if (dataFlowChain.Nodes != null)
+            {
+                foreach (var node in dataFlowChain.Nodes)
+                {
+                    WriteDataFlowNode(writer, node);
+                }
+            }
+        }
+
+        private static DataFlowChain ReadDataFlowChain(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            var chainId = ReadString(reader);
+            var sourceVariable = ReadString(reader);
+            var pattern = (DataFlowPattern)reader.ReadInt32();
+            var severity = (Severity)reader.ReadInt32();
+            var summary = ReadString(reader);
+            var methodLocation = ReadString(reader);
+
+            var dataFlowChain = new DataFlowChain(chainId, pattern, severity, summary, methodLocation)
+            {
+                SourceVariable = sourceVariable,
+                IsCrossMethod = reader.ReadBoolean(),
+                InvolvedMethods = ReadStringList(reader)
+            };
+
+            var nodeCount = reader.ReadInt32();
+            for (var i = 0; i < nodeCount; i++)
+            {
+                dataFlowChain.AppendNode(ReadDataFlowNode(reader));
+            }
+
+            return dataFlowChain;
+        }
+
+        private static void WriteDataFlowNode(BinaryWriter writer, DataFlowNode node)
+        {
+            var value = node ?? new DataFlowNode(string.Empty, string.Empty, DataFlowNodeType.Intermediate, string.Empty, 0);
+            WriteString(writer, value.Location);
+            WriteString(writer, value.Operation);
+            writer.Write((int)value.NodeType);
+            WriteString(writer, value.DataDescription);
+            writer.Write(value.InstructionOffset);
+            WriteString(writer, value.CodeSnippet);
+            WriteString(writer, value.MethodKey);
+            writer.Write(value.IsMethodBoundary);
+            WriteString(writer, value.TargetMethodKey);
+        }
+
+        private static DataFlowNode ReadDataFlowNode(BinaryReader reader)
+        {
+            var node = new DataFlowNode(
+                ReadString(reader),
+                ReadString(reader),
+                (DataFlowNodeType)reader.ReadInt32(),
+                ReadString(reader),
+                reader.ReadInt32(),
+                ReadString(reader),
+                ReadString(reader))
+            {
+                IsMethodBoundary = reader.ReadBoolean(),
+                TargetMethodKey = ReadString(reader)
+            };
+
+            return node;
+        }
+
+        private static void WriteStringList(BinaryWriter writer, List<string> values)
+        {
+            var list = values ?? new List<string>();
+            writer.Write(list.Count);
+            foreach (var value in list)
+            {
+                WriteString(writer, value);
+            }
+        }
+
+        private static List<string> ReadStringList(BinaryReader reader)
+        {
+            var count = reader.ReadInt32();
+            var values = new List<string>(Math.Max(count, 0));
+            for (var i = 0; i < count; i++)
+            {
+                values.Add(ReadString(reader));
+            }
+
+            return values;
+        }
+
+        private static void WriteString(BinaryWriter writer, string value)
+        {
+            writer.Write(value != null);
+            if (value != null)
+            {
+                writer.Write(value);
+            }
+        }
+
+        private static string ReadString(BinaryReader reader)
+        {
+            return reader.ReadBoolean() ? reader.ReadString() : string.Empty;
+        }
+    }
+}

--- a/Services/Caching/ScanCacheEnvelopeCodec.cs
+++ b/Services/Caching/ScanCacheEnvelopeCodec.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using MLVScan.Abstractions;
 using MLVScan.Models;
 
 namespace MLVScan.Services.Caching

--- a/Services/Caching/ScanCacheEnvelopeCodec.cs
+++ b/Services/Caching/ScanCacheEnvelopeCodec.cs
@@ -10,7 +10,7 @@ namespace MLVScan.Services.Caching
     internal static class ScanCacheEnvelopeCodec
     {
         private const int EnvelopeMagic = 0x4D4C5643;
-        private const int EnvelopeVersion = 1;
+        private const int EnvelopeVersion = 2;
 
         public static byte[] SerializePayload(ScanCacheEntryPayload payload)
         {
@@ -147,6 +147,7 @@ namespace MLVScan.Services.Caching
             WriteString(writer, value.FileHash);
             WriteFindings(writer, value.Findings);
             WriteThreatVerdict(writer, value.ThreatVerdict);
+            WriteScanStatus(writer, value.ScanStatus);
         }
 
         private static ScannedPluginResult ReadResult(BinaryReader reader)
@@ -156,7 +157,8 @@ namespace MLVScan.Services.Caching
                 FilePath = ReadString(reader),
                 FileHash = ReadString(reader),
                 Findings = ReadFindings(reader),
-                ThreatVerdict = ReadThreatVerdict(reader) ?? new ThreatVerdictInfo()
+                ThreatVerdict = ReadThreatVerdict(reader) ?? new ThreatVerdictInfo(),
+                ScanStatus = ReadScanStatus(reader) ?? new ScanStatusInfo()
             };
         }
 
@@ -286,6 +288,34 @@ namespace MLVScan.Services.Caching
                 ShouldBypassThreshold = reader.ReadBoolean(),
                 PrimaryFamily = ReadThreatFamily(reader),
                 Families = ReadThreatFamilies(reader)
+            };
+        }
+
+        private static void WriteScanStatus(BinaryWriter writer, ScanStatusInfo scanStatus)
+        {
+            writer.Write(scanStatus != null);
+            if (scanStatus == null)
+            {
+                return;
+            }
+
+            writer.Write((int)scanStatus.Kind);
+            WriteString(writer, scanStatus.Title);
+            WriteString(writer, scanStatus.Summary);
+        }
+
+        private static ScanStatusInfo ReadScanStatus(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            return new ScanStatusInfo
+            {
+                Kind = (ScanStatusKind)reader.ReadInt32(),
+                Title = ReadString(reader),
+                Summary = ReadString(reader)
             };
         }
 

--- a/Services/Caching/ScanCacheEnvelopeCodec.cs
+++ b/Services/Caching/ScanCacheEnvelopeCodec.cs
@@ -38,12 +38,10 @@ namespace MLVScan.Services.Caching
         public static bool TryDeserializeEnvelope(
             byte[] envelopeBytes,
             out string signature,
-            out byte[] payloadBytes,
-            out ScanCacheEntryPayload payload)
+            out byte[] payloadBytes)
         {
             signature = string.Empty;
             payloadBytes = Array.Empty<byte>();
-            payload = null;
 
             if (envelopeBytes == null || envelopeBytes.Length == 0)
             {
@@ -73,19 +71,17 @@ namespace MLVScan.Services.Caching
                     return false;
                 }
 
-                payload = DeserializePayload(payloadBytes);
-                return payload != null;
+                return true;
             }
             catch
             {
                 signature = string.Empty;
                 payloadBytes = Array.Empty<byte>();
-                payload = null;
                 return false;
             }
         }
 
-        private static ScanCacheEntryPayload DeserializePayload(byte[] payloadBytes)
+        public static ScanCacheEntryPayload DeserializePayload(byte[] payloadBytes)
         {
             using var memory = new MemoryStream(payloadBytes, writable: false);
             using var reader = new BinaryReader(memory, Encoding.UTF8, true);
@@ -193,6 +189,7 @@ namespace MLVScan.Services.Caching
             writer.Write((int)value.Severity);
             WriteString(writer, value.CodeSnippet);
             WriteString(writer, value.RuleId);
+            WriteDeveloperGuidance(writer, value.DeveloperGuidance);
             writer.Write(value.BypassCompanionCheck);
             writer.Write(value.RiskScore.HasValue);
             if (value.RiskScore.HasValue)
@@ -213,6 +210,7 @@ namespace MLVScan.Services.Caching
                 ReadString(reader))
             {
                 RuleId = ReadString(reader),
+                DeveloperGuidance = ReadDeveloperGuidance(reader),
                 BypassCompanionCheck = reader.ReadBoolean()
             };
 
@@ -224,6 +222,34 @@ namespace MLVScan.Services.Caching
             finding.CallChain = ReadCallChain(reader);
             finding.DataFlowChain = ReadDataFlowChain(reader);
             return finding;
+        }
+
+        private static void WriteDeveloperGuidance(BinaryWriter writer, IDeveloperGuidance guidance)
+        {
+            writer.Write(guidance != null);
+            if (guidance == null)
+            {
+                return;
+            }
+
+            WriteString(writer, guidance.Remediation);
+            WriteString(writer, guidance.DocumentationUrl);
+            WriteStringArray(writer, guidance.AlternativeApis);
+            writer.Write(guidance.IsRemediable);
+        }
+
+        private static IDeveloperGuidance ReadDeveloperGuidance(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            return new DeveloperGuidance(
+                ReadString(reader),
+                ReadString(reader),
+                ReadStringArray(reader),
+                reader.ReadBoolean());
         }
 
         private static void WriteThreatVerdict(BinaryWriter writer, ThreatVerdictInfo verdict)
@@ -493,6 +519,38 @@ namespace MLVScan.Services.Caching
             for (var i = 0; i < count; i++)
             {
                 values.Add(ReadString(reader));
+            }
+
+            return values;
+        }
+
+        private static void WriteStringArray(BinaryWriter writer, string[] values)
+        {
+            writer.Write(values != null);
+            if (values == null)
+            {
+                return;
+            }
+
+            writer.Write(values.Length);
+            foreach (var value in values)
+            {
+                WriteString(writer, value);
+            }
+        }
+
+        private static string[] ReadStringArray(BinaryReader reader)
+        {
+            if (!reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            var count = reader.ReadInt32();
+            var values = new string[Math.Max(count, 0)];
+            for (var i = 0; i < count; i++)
+            {
+                values[i] = ReadString(reader);
             }
 
             return values;

--- a/Services/Caching/ScanCacheModels.cs
+++ b/Services/Caching/ScanCacheModels.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MLVScan.Models;
+
+namespace MLVScan.Services.Caching
+{
+    internal sealed class ScanCacheEntry
+    {
+        public string CanonicalPath { get; set; } = string.Empty;
+
+        public string RealPath { get; set; } = string.Empty;
+
+        public FileIdentitySnapshot FileIdentity { get; set; } = new FileIdentitySnapshot();
+
+        public string Sha256 { get; set; } = string.Empty;
+
+        public string ScannerFingerprint { get; set; } = string.Empty;
+
+        public string ResolverFingerprint { get; set; } = string.Empty;
+
+        public DateTime CreatedUtc { get; set; }
+
+        public DateTime VerifiedUtc { get; set; }
+
+        public ScannedPluginResult Result { get; set; } = new ScannedPluginResult();
+
+        public bool CanReuseStrictly(FileProbe probe, string scannerFingerprint, string resolverFingerprint, bool canTrustCleanEntries)
+        {
+            if (probe == null)
+            {
+                return false;
+            }
+
+            if (!string.Equals(ScannerFingerprint, scannerFingerprint, StringComparison.Ordinal) ||
+                !string.Equals(ResolverFingerprint, resolverFingerprint, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            if (Result?.ThreatVerdict?.Kind == ThreatVerdictKind.None &&
+                !canTrustCleanEntries)
+            {
+                return false;
+            }
+
+            return probe.CanReuseByStrongIdentity &&
+                   FileIdentity.MatchesStrongIdentity(probe.Identity);
+        }
+
+        public ScannedPluginResult CloneResultForPath(string filePath)
+        {
+            var findings = new List<ScanFinding>(Result?.Findings?.Count ?? 0);
+            if (Result?.Findings != null)
+            {
+                foreach (var finding in Result.Findings)
+                {
+                    var clonedFinding = new ScanFinding(
+                        finding.Location,
+                        finding.Description,
+                        finding.Severity,
+                        finding.CodeSnippet)
+                    {
+                        RuleId = finding.RuleId,
+                        DeveloperGuidance = finding.DeveloperGuidance,
+                        CallChain = finding.CallChain,
+                        DataFlowChain = finding.DataFlowChain,
+                        BypassCompanionCheck = finding.BypassCompanionCheck,
+                        RiskScore = finding.RiskScore
+                    };
+
+                    findings.Add(clonedFinding);
+                }
+            }
+
+            ThreatVerdictInfo verdict = null;
+            if (Result?.ThreatVerdict != null)
+            {
+                verdict = new ThreatVerdictInfo
+                {
+                    Kind = Result.ThreatVerdict.Kind,
+                    Title = Result.ThreatVerdict.Title,
+                    Summary = Result.ThreatVerdict.Summary,
+                    Confidence = Result.ThreatVerdict.Confidence,
+                    ShouldBypassThreshold = Result.ThreatVerdict.ShouldBypassThreshold,
+                    PrimaryFamily = CloneFamily(Result.ThreatVerdict.PrimaryFamily),
+                    Families = Result.ThreatVerdict.Families?
+                        .Select(CloneFamily)
+                        .ToList() ?? new List<ThreatFamilyReference>()
+                };
+            }
+
+            return new ScannedPluginResult
+            {
+                FilePath = filePath,
+                FileHash = Result?.FileHash ?? Sha256,
+                Findings = findings,
+                ThreatVerdict = verdict ?? new ThreatVerdictInfo()
+            };
+        }
+
+        private static ThreatFamilyReference CloneFamily(ThreatFamilyReference family)
+        {
+            if (family == null)
+            {
+                return null;
+            }
+
+            return new ThreatFamilyReference
+            {
+                FamilyId = family.FamilyId,
+                DisplayName = family.DisplayName,
+                Summary = family.Summary,
+                MatchKind = family.MatchKind,
+                TechnicalName = family.TechnicalName,
+                ReferenceUrl = family.ReferenceUrl,
+                Confidence = family.Confidence,
+                ExactHashMatch = family.ExactHashMatch,
+                MatchedRules = family.MatchedRules?.ToList() ?? new List<string>(),
+                Evidence = family.Evidence?.ToList() ?? new List<string>()
+            };
+        }
+    }
+
+    internal sealed class ScanCacheEnvelope
+    {
+        public int SchemaVersion { get; set; } = 1;
+
+        public string Signature { get; set; } = string.Empty;
+
+        public ScanCacheEntryPayload Payload { get; set; } = new ScanCacheEntryPayload();
+    }
+
+    internal sealed class ScanCacheEntryPayload
+    {
+        public string CanonicalPath { get; set; } = string.Empty;
+
+        public string RealPath { get; set; } = string.Empty;
+
+        public FileIdentitySnapshot FileIdentity { get; set; } = new FileIdentitySnapshot();
+
+        public string Sha256 { get; set; } = string.Empty;
+
+        public string ScannerFingerprint { get; set; } = string.Empty;
+
+        public string ResolverFingerprint { get; set; } = string.Empty;
+
+        public DateTime CreatedUtc { get; set; }
+
+        public DateTime VerifiedUtc { get; set; }
+
+        public ScannedPluginResult Result { get; set; } = new ScannedPluginResult();
+
+        public ScanCacheEntry ToEntry()
+        {
+            return new ScanCacheEntry
+            {
+                CanonicalPath = CanonicalPath,
+                RealPath = RealPath,
+                FileIdentity = FileIdentity,
+                Sha256 = Sha256,
+                ScannerFingerprint = ScannerFingerprint,
+                ResolverFingerprint = ResolverFingerprint,
+                CreatedUtc = CreatedUtc,
+                VerifiedUtc = VerifiedUtc,
+                Result = Result
+            };
+        }
+
+        public static ScanCacheEntryPayload FromEntry(ScanCacheEntry entry)
+        {
+            return new ScanCacheEntryPayload
+            {
+                CanonicalPath = entry.CanonicalPath,
+                RealPath = entry.RealPath,
+                FileIdentity = entry.FileIdentity,
+                Sha256 = entry.Sha256,
+                ScannerFingerprint = entry.ScannerFingerprint,
+                ResolverFingerprint = entry.ResolverFingerprint,
+                CreatedUtc = entry.CreatedUtc,
+                VerifiedUtc = entry.VerifiedUtc,
+                Result = entry.Result
+            };
+        }
+    }
+}

--- a/Services/Caching/ScanCacheModels.cs
+++ b/Services/Caching/ScanCacheModels.cs
@@ -41,7 +41,7 @@ namespace MLVScan.Services.Caching
                 return false;
             }
 
-            if (Result?.ThreatVerdict?.Kind == ThreatVerdictKind.None &&
+            if (!ScanResultFacts.HasThreatVerdict(Result) &&
                 !canTrustCleanEntries)
             {
                 return false;
@@ -93,12 +93,24 @@ namespace MLVScan.Services.Caching
                 };
             }
 
+            ScanStatusInfo scanStatus = null;
+            if (Result?.ScanStatus != null)
+            {
+                scanStatus = new ScanStatusInfo
+                {
+                    Kind = Result.ScanStatus.Kind,
+                    Title = Result.ScanStatus.Title,
+                    Summary = Result.ScanStatus.Summary
+                };
+            }
+
             return new ScannedPluginResult
             {
                 FilePath = filePath,
                 FileHash = Result?.FileHash ?? Sha256,
                 Findings = findings,
-                ThreatVerdict = verdict ?? new ThreatVerdictInfo()
+                ThreatVerdict = verdict ?? new ThreatVerdictInfo(),
+                ScanStatus = scanStatus ?? new ScanStatusInfo()
             };
         }
 
@@ -127,7 +139,7 @@ namespace MLVScan.Services.Caching
 
     internal sealed class ScanCacheEnvelope
     {
-        public int SchemaVersion { get; set; } = 1;
+        public int SchemaVersion { get; set; } = 2;
 
         public string Signature { get; set; } = string.Empty;
 

--- a/Services/Caching/ScanCacheModels.cs
+++ b/Services/Caching/ScanCacheModels.cs
@@ -25,6 +25,9 @@ namespace MLVScan.Services.Caching
 
         public ScannedPluginResult Result { get; set; } = new ScannedPluginResult();
 
+        // ScanCacheEntry / ScanCacheEntryPayload conversions intentionally keep shallow FileIdentity
+        // and Result references for performance. Call CloneResultForPath when mutation-safe Result
+        // data is required instead of relying on ToEntry or FromEntry to deep-copy it.
         public bool CanReuseStrictly(FileProbe probe, string scannerFingerprint, string resolverFingerprint, bool canTrustCleanEntries)
         {
             if (probe == null)
@@ -151,6 +154,8 @@ namespace MLVScan.Services.Caching
 
         public ScannedPluginResult Result { get; set; } = new ScannedPluginResult();
 
+        // ToEntry and FromEntry intentionally keep ScanCacheEntry / ScanCacheEntryPayload shallow for
+        // FileIdentity and Result. Use CloneResultForPath when callers need a deep-cloned Result.
         public ScanCacheEntry ToEntry()
         {
             return new ScanCacheEntry

--- a/Services/Caching/ScanCacheSigner.cs
+++ b/Services/Caching/ScanCacheSigner.cs
@@ -74,18 +74,22 @@ namespace MLVScan.Services.Caching
                 var existingSecret = File.ReadAllBytes(secretPath);
                 try
                 {
-                    return UnprotectForCurrentUser(existingSecret);
+                    var unprotectedSecret = UnprotectForCurrentUser(existingSecret);
+                    if (IsValidSecret(unprotectedSecret))
+                    {
+                        return unprotectedSecret;
+                    }
                 }
                 catch
                 {
-                    if (existingSecret.Length == 32)
+                    if (IsValidSecret(existingSecret))
                     {
                         canTrustCleanEntries = false;
                         return existingSecret;
                     }
-
-                    throw;
                 }
+
+                DeleteInvalidSecret(secretPath);
             }
 
             Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
@@ -111,7 +115,13 @@ namespace MLVScan.Services.Caching
 
             if (File.Exists(secretPath))
             {
-                return File.ReadAllBytes(secretPath);
+                var existingSecret = File.ReadAllBytes(secretPath);
+                if (IsValidSecret(existingSecret))
+                {
+                    return existingSecret;
+                }
+
+                DeleteInvalidSecret(secretPath);
             }
 
             var secret = CreateRandomSecret();
@@ -212,6 +222,26 @@ namespace MLVScan.Services.Caching
             using var random = RandomNumberGenerator.Create();
             random.GetBytes(bytes);
             return bytes;
+        }
+
+        private static bool IsValidSecret(byte[] secret)
+        {
+            return secret != null && secret.Length == 32;
+        }
+
+        private static void DeleteInvalidSecret(string secretPath)
+        {
+            try
+            {
+                if (File.Exists(secretPath))
+                {
+                    File.Delete(secretPath);
+                }
+            }
+            catch
+            {
+                // Ignore invalid secret cleanup failures and fall back to untrusted/no cache.
+            }
         }
 
         [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/Services/Caching/ScanCacheSigner.cs
+++ b/Services/Caching/ScanCacheSigner.cs
@@ -1,0 +1,140 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Mono.Unix.Native;
+
+namespace MLVScan.Services.Caching
+{
+    internal sealed class ScanCacheSigner : IScanCacheSigner
+    {
+        private readonly byte[] _secret;
+
+        public ScanCacheSigner(string cacheDirectory)
+        {
+            var secretPath = Path.Combine(cacheDirectory, "secret.bin");
+            _secret = LoadOrCreateSecret(secretPath, out var canTrustCleanEntries);
+            CanTrustCleanEntries = canTrustCleanEntries && _secret.Length > 0;
+        }
+
+        public bool CanTrustCleanEntries { get; }
+
+        public string Sign(string payloadJson)
+        {
+            if (string.IsNullOrEmpty(payloadJson) || _secret.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            using var hmac = new HMACSHA256(_secret);
+            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payloadJson));
+            return Convert.ToBase64String(hash);
+        }
+
+        public bool Verify(string payloadJson, string signature)
+        {
+            if (string.IsNullOrEmpty(payloadJson) ||
+                string.IsNullOrEmpty(signature) ||
+                _secret.Length == 0)
+            {
+                return false;
+            }
+
+            var expected = Sign(payloadJson);
+            return CryptographicOperations.FixedTimeEquals(
+                Encoding.UTF8.GetBytes(expected),
+                Encoding.UTF8.GetBytes(signature));
+        }
+
+        private static byte[] LoadOrCreateSecret(string secretPath, out bool canTrustCleanEntries)
+        {
+            canTrustCleanEntries = false;
+
+            try
+            {
+                if (RuntimeInformationHelper.IsWindows)
+                {
+                    return LoadOrCreateWindowsSecret(secretPath, out canTrustCleanEntries);
+                }
+
+                return LoadOrCreateUnixSecret(secretPath, out canTrustCleanEntries);
+            }
+            catch
+            {
+                canTrustCleanEntries = false;
+                return Array.Empty<byte>();
+            }
+        }
+
+        private static byte[] LoadOrCreateWindowsSecret(string secretPath, out bool canTrustCleanEntries)
+        {
+            canTrustCleanEntries = true;
+#pragma warning disable CA1416
+            if (File.Exists(secretPath))
+            {
+                var existingSecret = File.ReadAllBytes(secretPath);
+                try
+                {
+                    return ProtectedData.Unprotect(existingSecret, null, DataProtectionScope.CurrentUser);
+                }
+                catch
+                {
+                    if (existingSecret.Length == 32)
+                    {
+                        return existingSecret;
+                    }
+
+                    throw;
+                }
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
+            var secret = CreateRandomSecret();
+            try
+            {
+                var protectedSecret = ProtectedData.Protect(secret, null, DataProtectionScope.CurrentUser);
+                AtomicFileStorage.WriteAllBytes(secretPath, protectedSecret);
+            }
+            catch
+            {
+                AtomicFileStorage.WriteAllBytes(secretPath, secret);
+            }
+
+            return secret;
+#pragma warning restore CA1416
+        }
+
+        private static byte[] LoadOrCreateUnixSecret(string secretPath, out bool canTrustCleanEntries)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
+            if (!File.Exists(secretPath))
+            {
+                var created = CreateRandomSecret();
+                AtomicFileStorage.WriteAllBytes(secretPath, created);
+                Syscall.chmod(secretPath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
+            }
+
+            canTrustCleanEntries = HasOwnerOnlyPermissions(secretPath);
+            return File.ReadAllBytes(secretPath);
+        }
+
+        private static bool HasOwnerOnlyPermissions(string secretPath)
+        {
+            if (Syscall.stat(secretPath, out var stat) != 0)
+            {
+                return false;
+            }
+
+            var forbidden = FilePermissions.S_IRWXG | FilePermissions.S_IRWXO;
+            return (stat.st_mode & forbidden) == 0;
+        }
+
+        private static byte[] CreateRandomSecret()
+        {
+            var bytes = new byte[32];
+            using var random = RandomNumberGenerator.Create();
+            random.GetBytes(bytes);
+            return bytes;
+        }
+    }
+}

--- a/Services/Caching/ScanCacheSigner.cs
+++ b/Services/Caching/ScanCacheSigner.cs
@@ -112,20 +112,28 @@ namespace MLVScan.Services.Caching
         {
             Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
             canTrustCleanEntries = false;
+            var foundInvalidSecret = false;
 
             if (File.Exists(secretPath))
             {
                 var existingSecret = File.ReadAllBytes(secretPath);
                 if (IsValidSecret(existingSecret))
                 {
+                    canTrustCleanEntries = true;
                     return existingSecret;
                 }
 
                 DeleteInvalidSecret(secretPath);
+                foundInvalidSecret = true;
             }
 
             var secret = CreateRandomSecret();
             AtomicFileStorage.WriteAllBytes(secretPath, secret);
+            if (!foundInvalidSecret)
+            {
+                canTrustCleanEntries = true;
+            }
+
             return secret;
         }
 

--- a/Services/Caching/ScanCacheSigner.cs
+++ b/Services/Caching/ScanCacheSigner.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
 using Mono.Unix.Native;
 
 namespace MLVScan.Services.Caching
@@ -81,6 +82,7 @@ namespace MLVScan.Services.Caching
                 {
                     if (existingSecret.Length == 32)
                     {
+                        canTrustCleanEntries = false;
                         return existingSecret;
                     }
 
@@ -97,6 +99,7 @@ namespace MLVScan.Services.Caching
             }
             catch
             {
+                canTrustCleanEntries = false;
                 AtomicFileStorage.WriteAllBytes(secretPath, secret);
             }
 
@@ -109,13 +112,65 @@ namespace MLVScan.Services.Caching
             Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
             if (!File.Exists(secretPath))
             {
-                var created = CreateRandomSecret();
-                AtomicFileStorage.WriteAllBytes(secretPath, created);
-                Syscall.chmod(secretPath, FilePermissions.S_IRUSR | FilePermissions.S_IWUSR);
+                CreateUnixSecret(secretPath, CreateRandomSecret());
             }
 
             canTrustCleanEntries = HasOwnerOnlyPermissions(secretPath);
             return File.ReadAllBytes(secretPath);
+        }
+
+        private static void CreateUnixSecret(string secretPath, byte[] secret)
+        {
+            const FilePermissions OwnerOnlyPermissions = FilePermissions.S_IRUSR | FilePermissions.S_IWUSR;
+            var fd = Syscall.open(secretPath, OpenFlags.O_CREAT | OpenFlags.O_EXCL | OpenFlags.O_WRONLY, OwnerOnlyPermissions);
+            if (fd < 0)
+            {
+                var errno = Stdlib.GetLastError();
+                if (errno == Errno.EEXIST)
+                {
+                    return;
+                }
+
+                throw CreateUnixIoException("open", secretPath, errno);
+            }
+
+            var success = false;
+            try
+            {
+                if (Syscall.fchmod(fd, OwnerOnlyPermissions) != 0)
+                {
+                    throw CreateUnixIoException("fchmod", secretPath);
+                }
+
+                using (var stream = new FileStream(new SafeFileHandle((IntPtr)fd, ownsHandle: false), FileAccess.Write))
+                {
+                    stream.Write(secret, 0, secret.Length);
+                    stream.Flush(true);
+                }
+
+                if (Syscall.fsync(fd) != 0)
+                {
+                    throw CreateUnixIoException("fsync", secretPath);
+                }
+
+                success = true;
+            }
+            finally
+            {
+                Syscall.close(fd);
+
+                if (!success && File.Exists(secretPath))
+                {
+                    try
+                    {
+                        File.Delete(secretPath);
+                    }
+                    catch
+                    {
+                        // Preserve the original failure if cleanup also fails.
+                    }
+                }
+            }
         }
 
         private static bool HasOwnerOnlyPermissions(string secretPath)
@@ -135,6 +190,11 @@ namespace MLVScan.Services.Caching
             using var random = RandomNumberGenerator.Create();
             random.GetBytes(bytes);
             return bytes;
+        }
+
+        private static IOException CreateUnixIoException(string operation, string path, Errno? errno = null)
+        {
+            return new IOException($"{operation} failed for {path}: {errno ?? Stdlib.GetLastError()}");
         }
     }
 }

--- a/Services/Caching/ScanCacheSigner.cs
+++ b/Services/Caching/ScanCacheSigner.cs
@@ -1,14 +1,15 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.Win32.SafeHandles;
-using Mono.Unix.Native;
 
 namespace MLVScan.Services.Caching
 {
     internal sealed class ScanCacheSigner : IScanCacheSigner
     {
+        private const int CryptProtectUiForbidden = 0x1;
+
         private readonly byte[] _secret;
 
         public ScanCacheSigner(string cacheDirectory)
@@ -20,31 +21,31 @@ namespace MLVScan.Services.Caching
 
         public bool CanTrustCleanEntries { get; }
 
-        public string Sign(string payloadJson)
+        public string Sign(byte[] payloadBytes)
         {
-            if (string.IsNullOrEmpty(payloadJson) || _secret.Length == 0)
+            if (payloadBytes == null || payloadBytes.Length == 0 || _secret.Length == 0)
             {
                 return string.Empty;
             }
 
             using var hmac = new HMACSHA256(_secret);
-            var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(payloadJson));
-            return Convert.ToBase64String(hash);
+            return Convert.ToBase64String(hmac.ComputeHash(payloadBytes));
         }
 
-        public bool Verify(string payloadJson, string signature)
+        public bool Verify(byte[] payloadBytes, string signature)
         {
-            if (string.IsNullOrEmpty(payloadJson) ||
+            if (payloadBytes == null ||
+                payloadBytes.Length == 0 ||
                 string.IsNullOrEmpty(signature) ||
                 _secret.Length == 0)
             {
                 return false;
             }
 
-            var expected = Sign(payloadJson);
-            return CryptographicOperations.FixedTimeEquals(
-                Encoding.UTF8.GetBytes(expected),
-                Encoding.UTF8.GetBytes(signature));
+            var expectedBytes = Encoding.UTF8.GetBytes(Sign(payloadBytes));
+            var actualBytes = Encoding.UTF8.GetBytes(signature);
+            return expectedBytes.Length == actualBytes.Length &&
+                   CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
         }
 
         private static byte[] LoadOrCreateSecret(string secretPath, out bool canTrustCleanEntries)
@@ -53,12 +54,9 @@ namespace MLVScan.Services.Caching
 
             try
             {
-                if (RuntimeInformationHelper.IsWindows)
-                {
-                    return LoadOrCreateWindowsSecret(secretPath, out canTrustCleanEntries);
-                }
-
-                return LoadOrCreateUnixSecret(secretPath, out canTrustCleanEntries);
+                return RuntimeInformationHelper.IsWindows
+                    ? LoadOrCreateWindowsSecret(secretPath, out canTrustCleanEntries)
+                    : LoadOrCreatePortableSecret(secretPath, out canTrustCleanEntries);
             }
             catch
             {
@@ -70,13 +68,13 @@ namespace MLVScan.Services.Caching
         private static byte[] LoadOrCreateWindowsSecret(string secretPath, out bool canTrustCleanEntries)
         {
             canTrustCleanEntries = true;
-#pragma warning disable CA1416
+
             if (File.Exists(secretPath))
             {
                 var existingSecret = File.ReadAllBytes(secretPath);
                 try
                 {
-                    return ProtectedData.Unprotect(existingSecret, null, DataProtectionScope.CurrentUser);
+                    return UnprotectForCurrentUser(existingSecret);
                 }
                 catch
                 {
@@ -94,7 +92,7 @@ namespace MLVScan.Services.Caching
             var secret = CreateRandomSecret();
             try
             {
-                var protectedSecret = ProtectedData.Protect(secret, null, DataProtectionScope.CurrentUser);
+                var protectedSecret = ProtectForCurrentUser(secret);
                 AtomicFileStorage.WriteAllBytes(secretPath, protectedSecret);
             }
             catch
@@ -104,84 +102,108 @@ namespace MLVScan.Services.Caching
             }
 
             return secret;
-#pragma warning restore CA1416
         }
 
-        private static byte[] LoadOrCreateUnixSecret(string secretPath, out bool canTrustCleanEntries)
+        private static byte[] LoadOrCreatePortableSecret(string secretPath, out bool canTrustCleanEntries)
         {
             Directory.CreateDirectory(Path.GetDirectoryName(secretPath)!);
-            if (!File.Exists(secretPath))
+            canTrustCleanEntries = false;
+
+            if (File.Exists(secretPath))
             {
-                CreateUnixSecret(secretPath, CreateRandomSecret());
+                return File.ReadAllBytes(secretPath);
             }
 
-            canTrustCleanEntries = HasOwnerOnlyPermissions(secretPath);
-            return File.ReadAllBytes(secretPath);
+            var secret = CreateRandomSecret();
+            AtomicFileStorage.WriteAllBytes(secretPath, secret);
+            return secret;
         }
 
-        private static void CreateUnixSecret(string secretPath, byte[] secret)
+        private static byte[] ProtectForCurrentUser(byte[] data)
         {
-            const FilePermissions OwnerOnlyPermissions = FilePermissions.S_IRUSR | FilePermissions.S_IWUSR;
-            var fd = Syscall.open(secretPath, OpenFlags.O_CREAT | OpenFlags.O_EXCL | OpenFlags.O_WRONLY, OwnerOnlyPermissions);
-            if (fd < 0)
-            {
-                var errno = Stdlib.GetLastError();
-                if (errno == Errno.EEXIST)
-                {
-                    return;
-                }
-
-                throw CreateUnixIoException("open", secretPath, errno);
-            }
-
-            var success = false;
+            var inputHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
             {
-                if (Syscall.fchmod(fd, OwnerOnlyPermissions) != 0)
+                var input = new DataBlob
                 {
-                    throw CreateUnixIoException("fchmod", secretPath);
+                    cbData = data.Length,
+                    pbData = inputHandle.AddrOfPinnedObject()
+                };
+
+                if (!CryptProtectData(ref input, null, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, CryptProtectUiForbidden, out var output))
+                {
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
                 }
 
-                using (var stream = new FileStream(new SafeFileHandle((IntPtr)fd, ownsHandle: false), FileAccess.Write))
+                try
                 {
-                    stream.Write(secret, 0, secret.Length);
-                    stream.Flush(true);
+                    return CopyOutputBlob(output);
                 }
-
-                if (Syscall.fsync(fd) != 0)
+                finally
                 {
-                    throw CreateUnixIoException("fsync", secretPath);
+                    FreeOutputBlob(output);
                 }
-
-                success = true;
             }
             finally
             {
-                Syscall.close(fd);
-
-                if (!success && File.Exists(secretPath))
-                {
-                    try
-                    {
-                        File.Delete(secretPath);
-                    }
-                    catch
-                    {
-                        // Preserve the original failure if cleanup also fails.
-                    }
-                }
+                inputHandle.Free();
             }
         }
 
-        private static bool HasOwnerOnlyPermissions(string secretPath)
+        private static byte[] UnprotectForCurrentUser(byte[] data)
         {
-            if (Syscall.stat(secretPath, out var stat) != 0)
+            var inputHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            try
             {
-                return false;
+                var input = new DataBlob
+                {
+                    cbData = data.Length,
+                    pbData = inputHandle.AddrOfPinnedObject()
+                };
+
+                if (!CryptUnprotectData(ref input, out var description, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, CryptProtectUiForbidden, out var output))
+                {
+                    throw new CryptographicException(Marshal.GetLastWin32Error());
+                }
+
+                try
+                {
+                    return CopyOutputBlob(output);
+                }
+                finally
+                {
+                    if (description != IntPtr.Zero)
+                    {
+                        LocalFree(description);
+                    }
+
+                    FreeOutputBlob(output);
+                }
+            }
+            finally
+            {
+                inputHandle.Free();
+            }
+        }
+
+        private static byte[] CopyOutputBlob(DataBlob blob)
+        {
+            if (blob.cbData <= 0 || blob.pbData == IntPtr.Zero)
+            {
+                return Array.Empty<byte>();
             }
 
-            var forbidden = FilePermissions.S_IRWXG | FilePermissions.S_IRWXO;
-            return (stat.st_mode & forbidden) == 0;
+            var bytes = new byte[blob.cbData];
+            Marshal.Copy(blob.pbData, bytes, 0, blob.cbData);
+            return bytes;
+        }
+
+        private static void FreeOutputBlob(DataBlob blob)
+        {
+            if (blob.pbData != IntPtr.Zero)
+            {
+                LocalFree(blob.pbData);
+            }
         }
 
         private static byte[] CreateRandomSecret()
@@ -192,9 +214,34 @@ namespace MLVScan.Services.Caching
             return bytes;
         }
 
-        private static IOException CreateUnixIoException(string operation, string path, Errno? errno = null)
+        [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CryptProtectData(
+            ref DataBlob pDataIn,
+            string szDataDescr,
+            IntPtr pOptionalEntropy,
+            IntPtr pvReserved,
+            IntPtr pPromptStruct,
+            int dwFlags,
+            out DataBlob pDataOut);
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CryptUnprotectData(
+            ref DataBlob pDataIn,
+            out IntPtr ppszDataDescr,
+            IntPtr pOptionalEntropy,
+            IntPtr pvReserved,
+            IntPtr pPromptStruct,
+            int dwFlags,
+            out DataBlob pDataOut);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern IntPtr LocalFree(IntPtr hMem);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct DataBlob
         {
-            return new IOException($"{operation} failed for {path}: {errno ?? Stdlib.GetLastError()}");
+            public int cbData;
+            public IntPtr pbData;
         }
     }
 }

--- a/Services/Caching/SecureScanCacheStore.cs
+++ b/Services/Caching/SecureScanCacheStore.cs
@@ -3,17 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 
 namespace MLVScan.Services.Caching
 {
     internal sealed class SecureScanCacheStore : IScanCacheStore
     {
-        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
-        {
-            WriteIndented = false
-        };
-
         private readonly Dictionary<string, ScanCacheEntry> _entriesByPath = new Dictionary<string, ScanCacheEntry>(GetPathComparer());
         private readonly Dictionary<string, ScanCacheEntry> _entriesByHash = new Dictionary<string, ScanCacheEntry>(StringComparer.OrdinalIgnoreCase);
         private readonly IScanCacheSigner _signer;
@@ -62,15 +56,9 @@ namespace MLVScan.Services.Caching
             entry.VerifiedUtc = DateTime.UtcNow;
 
             var payload = ScanCacheEntryPayload.FromEntry(entry);
-            var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
-            var envelope = new ScanCacheEnvelope
-            {
-                Signature = _signer.Sign(payloadJson),
-                Payload = payload
-            };
-
-            var envelopeJson = JsonSerializer.Serialize(envelope, JsonOptions);
-            AtomicFileStorage.WriteAllText(GetEntryFilePath(entry.CanonicalPath), envelopeJson);
+            var payloadBytes = ScanCacheEnvelopeCodec.SerializePayload(payload);
+            var envelopeBytes = ScanCacheEnvelopeCodec.SerializeEnvelope(_signer.Sign(payloadBytes), payloadBytes);
+            AtomicFileStorage.WriteAllBytes(GetEntryFilePath(entry.CanonicalPath), envelopeBytes);
 
             var normalizedPath = NormalizePathKey(entry.CanonicalPath);
             _entriesByPath[normalizedPath] = entry;
@@ -101,10 +89,12 @@ namespace MLVScan.Services.Caching
 
             try
             {
-                var path = GetEntryFilePath(canonicalPath);
-                if (File.Exists(path))
+                foreach (var path in GetEntryFilePaths(canonicalPath))
                 {
-                    File.Delete(path);
+                    if (File.Exists(path))
+                    {
+                        File.Delete(path);
+                    }
                 }
             }
             catch
@@ -132,26 +122,30 @@ namespace MLVScan.Services.Caching
 
         private void LoadEntries()
         {
-            foreach (var path in Directory.EnumerateFiles(_entriesDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            if (!Directory.Exists(_entriesDirectory))
+            {
+                return;
+            }
+
+            foreach (var path in EnumerateEntryFiles())
             {
                 try
                 {
-                    var json = File.ReadAllText(path);
-                    var envelope = JsonSerializer.Deserialize<ScanCacheEnvelope>(json, JsonOptions);
-                    if (envelope?.Payload == null || envelope.SchemaVersion != 1)
+                    var envelopeBytes = File.ReadAllBytes(path);
+                    if (!ScanCacheEnvelopeCodec.TryDeserializeEnvelope(envelopeBytes, out var signature, out var payloadBytes, out var payload) ||
+                        payload == null)
                     {
                         DeleteCorruptEntry(path);
                         continue;
                     }
 
-                    var payloadJson = JsonSerializer.Serialize(envelope.Payload, JsonOptions);
-                    if (!_signer.Verify(payloadJson, envelope.Signature))
+                    if (!_signer.Verify(payloadBytes, signature))
                     {
                         DeleteCorruptEntry(path);
                         continue;
                     }
 
-                    var entry = envelope.Payload.ToEntry();
+                    var entry = payload.ToEntry();
                     var normalizedPath = NormalizePathKey(entry.CanonicalPath);
                     _entriesByPath[normalizedPath] = entry;
                     if (!string.IsNullOrWhiteSpace(entry.Sha256))
@@ -181,7 +175,27 @@ namespace MLVScan.Services.Caching
         private string GetEntryFilePath(string canonicalPath)
         {
             var key = HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(NormalizePathKey(canonicalPath)));
-            return Path.Combine(_entriesDirectory, $"{key}.json");
+            return Path.Combine(_entriesDirectory, $"{key}.cache");
+        }
+
+        private IEnumerable<string> GetEntryFilePaths(string canonicalPath)
+        {
+            var key = HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(NormalizePathKey(canonicalPath)));
+            yield return Path.Combine(_entriesDirectory, $"{key}.cache");
+            yield return Path.Combine(_entriesDirectory, $"{key}.json");
+        }
+
+        private IEnumerable<string> EnumerateEntryFiles()
+        {
+            foreach (var path in Directory.EnumerateFiles(_entriesDirectory, "*.cache", SearchOption.TopDirectoryOnly))
+            {
+                yield return path;
+            }
+
+            foreach (var path in Directory.EnumerateFiles(_entriesDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                yield return path;
+            }
         }
 
         private static string NormalizePathKey(string path)

--- a/Services/Caching/SecureScanCacheStore.cs
+++ b/Services/Caching/SecureScanCacheStore.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace MLVScan.Services.Caching
+{
+    internal sealed class SecureScanCacheStore : IScanCacheStore
+    {
+        private static readonly JsonSerializerOptions JsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false
+        };
+
+        private readonly Dictionary<string, ScanCacheEntry> _entriesByPath = new Dictionary<string, ScanCacheEntry>(GetPathComparer());
+        private readonly Dictionary<string, ScanCacheEntry> _entriesByHash = new Dictionary<string, ScanCacheEntry>(StringComparer.OrdinalIgnoreCase);
+        private readonly IScanCacheSigner _signer;
+        private readonly string _entriesDirectory;
+
+        public SecureScanCacheStore(string cacheDirectory, IScanCacheSigner signer)
+        {
+            _signer = signer ?? throw new ArgumentNullException(nameof(signer));
+            _entriesDirectory = Path.Combine(cacheDirectory ?? throw new ArgumentNullException(nameof(cacheDirectory)), "entries");
+            Directory.CreateDirectory(_entriesDirectory);
+            LoadEntries();
+        }
+
+        public bool CanTrustCleanEntries => _signer.CanTrustCleanEntries;
+
+        public ScanCacheEntry TryGetByPath(string canonicalPath)
+        {
+            if (string.IsNullOrWhiteSpace(canonicalPath))
+            {
+                return null;
+            }
+
+            _entriesByPath.TryGetValue(NormalizePathKey(canonicalPath), out var entry);
+            return entry;
+        }
+
+        public ScanCacheEntry TryGetByHash(string sha256Hash)
+        {
+            if (string.IsNullOrWhiteSpace(sha256Hash))
+            {
+                return null;
+            }
+
+            _entriesByHash.TryGetValue(sha256Hash, out var entry);
+            return entry;
+        }
+
+        public void Upsert(ScanCacheEntry entry)
+        {
+            if (entry == null || string.IsNullOrWhiteSpace(entry.CanonicalPath))
+            {
+                return;
+            }
+
+            entry.CreatedUtc = entry.CreatedUtc == default ? DateTime.UtcNow : entry.CreatedUtc;
+            entry.VerifiedUtc = DateTime.UtcNow;
+
+            var payload = ScanCacheEntryPayload.FromEntry(entry);
+            var payloadJson = JsonSerializer.Serialize(payload, JsonOptions);
+            var envelope = new ScanCacheEnvelope
+            {
+                Signature = _signer.Sign(payloadJson),
+                Payload = payload
+            };
+
+            var envelopeJson = JsonSerializer.Serialize(envelope, JsonOptions);
+            AtomicFileStorage.WriteAllText(GetEntryFilePath(entry.CanonicalPath), envelopeJson);
+
+            var normalizedPath = NormalizePathKey(entry.CanonicalPath);
+            _entriesByPath[normalizedPath] = entry;
+            if (!string.IsNullOrWhiteSpace(entry.Sha256))
+            {
+                _entriesByHash[entry.Sha256] = entry;
+            }
+        }
+
+        public void Remove(string canonicalPath)
+        {
+            if (string.IsNullOrWhiteSpace(canonicalPath))
+            {
+                return;
+            }
+
+            var normalizedPath = NormalizePathKey(canonicalPath);
+            if (_entriesByPath.TryGetValue(normalizedPath, out var existing))
+            {
+                _entriesByPath.Remove(normalizedPath);
+                if (!string.IsNullOrWhiteSpace(existing.Sha256) &&
+                    _entriesByHash.TryGetValue(existing.Sha256, out var hashEntry) &&
+                    ReferenceEquals(hashEntry, existing))
+                {
+                    _entriesByHash.Remove(existing.Sha256);
+                }
+            }
+
+            try
+            {
+                var path = GetEntryFilePath(canonicalPath);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // Ignore cache cleanup failures.
+            }
+        }
+
+        public void PruneMissingEntries(IReadOnlyCollection<string> activeCanonicalPaths)
+        {
+            var normalizedActive = new HashSet<string>(
+                activeCanonicalPaths?.Select(NormalizePathKey) ?? Enumerable.Empty<string>(),
+                GetPathComparer());
+
+            foreach (var entryPath in _entriesByPath.Keys.ToArray())
+            {
+                if (normalizedActive.Contains(entryPath))
+                {
+                    continue;
+                }
+
+                Remove(entryPath);
+            }
+        }
+
+        private void LoadEntries()
+        {
+            foreach (var path in Directory.EnumerateFiles(_entriesDirectory, "*.json", SearchOption.TopDirectoryOnly))
+            {
+                try
+                {
+                    var json = File.ReadAllText(path);
+                    var envelope = JsonSerializer.Deserialize<ScanCacheEnvelope>(json, JsonOptions);
+                    if (envelope?.Payload == null || envelope.SchemaVersion != 1)
+                    {
+                        DeleteCorruptEntry(path);
+                        continue;
+                    }
+
+                    var payloadJson = JsonSerializer.Serialize(envelope.Payload, JsonOptions);
+                    if (!_signer.Verify(payloadJson, envelope.Signature))
+                    {
+                        DeleteCorruptEntry(path);
+                        continue;
+                    }
+
+                    var entry = envelope.Payload.ToEntry();
+                    var normalizedPath = NormalizePathKey(entry.CanonicalPath);
+                    _entriesByPath[normalizedPath] = entry;
+                    if (!string.IsNullOrWhiteSpace(entry.Sha256))
+                    {
+                        _entriesByHash[entry.Sha256] = entry;
+                    }
+                }
+                catch
+                {
+                    DeleteCorruptEntry(path);
+                }
+            }
+        }
+
+        private void DeleteCorruptEntry(string path)
+        {
+            try
+            {
+                File.Delete(path);
+            }
+            catch
+            {
+                // Ignore corrupt cache cleanup failures.
+            }
+        }
+
+        private string GetEntryFilePath(string canonicalPath)
+        {
+            var key = HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(NormalizePathKey(canonicalPath)));
+            return Path.Combine(_entriesDirectory, $"{key}.json");
+        }
+
+        private static string NormalizePathKey(string path)
+        {
+            var normalized = Path.GetFullPath(path);
+            return RuntimeInformationHelper.IsWindows
+                ? normalized.ToLowerInvariant()
+                : normalized;
+        }
+
+        private static StringComparer GetPathComparer()
+        {
+            return RuntimeInformationHelper.IsWindows
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
+        }
+    }
+}

--- a/Services/Caching/SecureScanCacheStore.cs
+++ b/Services/Caching/SecureScanCacheStore.cs
@@ -61,11 +61,7 @@ namespace MLVScan.Services.Caching
             AtomicFileStorage.WriteAllBytes(GetEntryFilePath(entry.CanonicalPath), envelopeBytes);
 
             var normalizedPath = NormalizePathKey(entry.CanonicalPath);
-            _entriesByPath[normalizedPath] = entry;
-            if (!string.IsNullOrWhiteSpace(entry.Sha256))
-            {
-                _entriesByHash[entry.Sha256] = entry;
-            }
+            IndexEntry(normalizedPath, entry);
         }
 
         public void Remove(string canonicalPath)
@@ -132,8 +128,7 @@ namespace MLVScan.Services.Caching
                 try
                 {
                     var envelopeBytes = File.ReadAllBytes(path);
-                    if (!ScanCacheEnvelopeCodec.TryDeserializeEnvelope(envelopeBytes, out var signature, out var payloadBytes, out var payload) ||
-                        payload == null)
+                    if (!ScanCacheEnvelopeCodec.TryDeserializeEnvelope(envelopeBytes, out var signature, out var payloadBytes))
                     {
                         DeleteCorruptEntry(path);
                         continue;
@@ -145,13 +140,16 @@ namespace MLVScan.Services.Caching
                         continue;
                     }
 
+                    var payload = ScanCacheEnvelopeCodec.DeserializePayload(payloadBytes);
+                    if (payload == null)
+                    {
+                        DeleteCorruptEntry(path);
+                        continue;
+                    }
+
                     var entry = payload.ToEntry();
                     var normalizedPath = NormalizePathKey(entry.CanonicalPath);
-                    _entriesByPath[normalizedPath] = entry;
-                    if (!string.IsNullOrWhiteSpace(entry.Sha256))
-                    {
-                        _entriesByHash[entry.Sha256] = entry;
-                    }
+                    IndexEntry(normalizedPath, entry);
                 }
                 catch
                 {
@@ -169,6 +167,23 @@ namespace MLVScan.Services.Caching
             catch
             {
                 // Ignore corrupt cache cleanup failures.
+            }
+        }
+
+        private void IndexEntry(string normalizedPath, ScanCacheEntry entry)
+        {
+            if (_entriesByPath.TryGetValue(normalizedPath, out var existing) &&
+                !string.IsNullOrWhiteSpace(existing.Sha256) &&
+                (string.IsNullOrWhiteSpace(entry.Sha256) ||
+                 !string.Equals(existing.Sha256, entry.Sha256, StringComparison.OrdinalIgnoreCase)))
+            {
+                _entriesByHash.Remove(existing.Sha256);
+            }
+
+            _entriesByPath[normalizedPath] = entry;
+            if (!string.IsNullOrWhiteSpace(entry.Sha256))
+            {
+                _entriesByHash[entry.Sha256] = entry;
             }
         }
 

--- a/Services/ConsentMessageHelper.cs
+++ b/Services/ConsentMessageHelper.cs
@@ -5,16 +5,28 @@ namespace MLVScan.Services
 {
     internal static class ConsentMessageHelper
     {
-        public static string GetUploadConsentMessage(string modName, string verdictKind)
+        public static string GetUploadConsentMessage(string modName, string verdictKind, bool wasBlocked = true)
         {
             var label = string.IsNullOrWhiteSpace(modName) ? "this mod" : modName;
             if (string.Equals(verdictKind, ThreatVerdictKind.KnownMaliciousSample.ToString(), StringComparison.Ordinal) ||
                 string.Equals(verdictKind, ThreatVerdictKind.KnownMalwareFamily.ToString(), StringComparison.Ordinal))
             {
-                return $"MLVScan identified {label} as likely malware and disabled it.";
+                return wasBlocked
+                    ? $"MLVScan identified {label} as likely malware and disabled it."
+                    : $"MLVScan identified {label} as likely malware, but it was not blocked by the current configuration.";
             }
 
-            return $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive.";
+            if (string.IsNullOrWhiteSpace(verdictKind) ||
+                string.Equals(verdictKind, ThreatVerdictKind.None.ToString(), StringComparison.Ordinal))
+            {
+                return wasBlocked
+                    ? $"MLVScan blocked {label} because it could not complete full analysis and manual review is required."
+                    : $"MLVScan could not complete full analysis of {label}, so manual review is required before you trust it.";
+            }
+
+            return wasBlocked
+                ? $"MLVScan blocked {label} because it triggered suspicious behavior. It may still be a false positive."
+                : $"MLVScan flagged {label} because it triggered suspicious behavior, but it was not blocked by the current configuration. It may still be a false positive.";
         }
     }
 }

--- a/Services/ConsentMessageHelper.cs
+++ b/Services/ConsentMessageHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using MLVScan.Models;
 
-namespace MLVScan.BepInEx
+namespace MLVScan.Services
 {
     internal static class ConsentMessageHelper
     {

--- a/Services/DeveloperReportGenerator.cs
+++ b/Services/DeveloperReportGenerator.cs
@@ -141,7 +141,12 @@ namespace MLVScan.Services
         /// <summary>
         /// Generates a developer-friendly file report with remediation guidance.
         /// </summary>
-        public string GenerateFileReport(string modName, string hash, List<ScanFinding> findings, ThreatVerdictInfo threatVerdict = null)
+        public string GenerateFileReport(
+            string modName,
+            string hash,
+            List<ScanFinding> findings,
+            ThreatVerdictInfo threatVerdict = null,
+            ScanStatusInfo scanStatus = null)
         {
             var sb = new StringBuilder();
             sb.AppendLine("======= MLVScan Developer Report =======");
@@ -155,6 +160,7 @@ namespace MLVScan.Services
             using (var verdictWriter = new StringWriter(sb))
             {
                 ThreatVerdictTextFormatter.WriteThreatVerdictSection(verdictWriter, threatVerdict);
+                ThreatVerdictTextFormatter.WriteScanStatusSection(verdictWriter, scanStatus);
             }
 
             var groupedByRule = findings

--- a/Services/Diagnostics/LoaderScanTelemetryHub.cs
+++ b/Services/Diagnostics/LoaderScanTelemetryHub.cs
@@ -1,15 +1,16 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 #if MLVSCAN_PROFILING
-using System.Text.Json;
 #endif
 
 namespace MLVScan.Services.Diagnostics
 {
-    internal sealed class LoaderScanTelemetryHub
+    public sealed class LoaderScanTelemetryHub
     {
         private LoaderScanProfileSnapshot _lastSnapshot;
 
@@ -105,7 +106,7 @@ namespace MLVScan.Services.Diagnostics
 #endif
         }
 
-        public LoaderScanProfileSnapshot GetLastSnapshot()
+        internal LoaderScanProfileSnapshot GetLastSnapshot()
         {
             return _lastSnapshot;
         }
@@ -118,19 +119,146 @@ namespace MLVScan.Services.Diagnostics
                 return null;
             }
 
-            Directory.CreateDirectory(diagnosticsDirectory);
-            var path = Path.Combine(diagnosticsDirectory, $"loader-scan-profile-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
-            var json = JsonSerializer.Serialize(_lastSnapshot, new JsonSerializerOptions
+            try
             {
-                WriteIndented = true
-            });
-            File.WriteAllText(path, json);
-            return path;
+                Directory.CreateDirectory(diagnosticsDirectory);
+                var path = Path.Combine(diagnosticsDirectory, $"loader-scan-profile-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+                File.WriteAllText(path, SerializeSnapshot(_lastSnapshot));
+                return path;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
 #else
             _ = diagnosticsDirectory;
             return null;
 #endif
         }
+
+#if MLVSCAN_PROFILING
+        private static string SerializeSnapshot(LoaderScanProfileSnapshot snapshot)
+        {
+            var builder = new StringBuilder(4096);
+            builder.AppendLine("{");
+            builder.Append("  \"runId\": ");
+            AppendJsonString(builder, snapshot.RunId);
+            builder.AppendLine(",");
+            builder.Append("  \"totalElapsedTicks\": ");
+            builder.Append(snapshot.TotalElapsedTicks.ToString(CultureInfo.InvariantCulture));
+            builder.AppendLine(",");
+            builder.AppendLine("  \"phases\": [");
+
+            var phases = snapshot.Phases ?? Array.Empty<LoaderScanPhaseTiming>();
+            for (var i = 0; i < phases.Count; i++)
+            {
+                var phase = phases[i];
+                builder.AppendLine("    {");
+                builder.Append("      \"name\": ");
+                AppendJsonString(builder, phase.Name);
+                builder.AppendLine(",");
+                builder.Append("      \"elapsedTicks\": ");
+                builder.Append(phase.ElapsedTicks.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine(",");
+                builder.Append("      \"count\": ");
+                builder.Append(phase.Count.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine();
+                builder.Append("    }");
+                builder.AppendLine(i < phases.Count - 1 ? "," : string.Empty);
+            }
+
+            builder.AppendLine("  ],");
+            builder.AppendLine("  \"counters\": {");
+
+            var counters = (snapshot.Counters ?? new Dictionary<string, long>(StringComparer.Ordinal)).ToArray();
+            for (var i = 0; i < counters.Length; i++)
+            {
+                var counter = counters[i];
+                builder.Append("    ");
+                AppendJsonString(builder, counter.Key);
+                builder.Append(": ");
+                builder.Append(counter.Value.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine(i < counters.Length - 1 ? "," : string.Empty);
+            }
+
+            builder.AppendLine("  },");
+            builder.AppendLine("  \"slowFiles\": [");
+
+            var files = snapshot.SlowFiles ?? Array.Empty<LoaderScanFileSample>();
+            for (var i = 0; i < files.Count; i++)
+            {
+                var file = files[i];
+                builder.AppendLine("    {");
+                builder.Append("      \"filePath\": ");
+                AppendJsonString(builder, file.FilePath);
+                builder.AppendLine(",");
+                builder.Append("      \"elapsedTicks\": ");
+                builder.Append(file.ElapsedTicks.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine(",");
+                builder.Append("      \"action\": ");
+                AppendJsonString(builder, file.Action);
+                builder.AppendLine(",");
+                builder.Append("      \"bytesRead\": ");
+                builder.Append(file.BytesRead.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine(",");
+                builder.Append("      \"findingsCount\": ");
+                builder.Append(file.FindingsCount.ToString(CultureInfo.InvariantCulture));
+                builder.AppendLine();
+                builder.Append("    }");
+                builder.AppendLine(i < files.Count - 1 ? "," : string.Empty);
+            }
+
+            builder.AppendLine("  ]");
+            builder.Append('}');
+            return builder.ToString();
+        }
+
+        private static void AppendJsonString(StringBuilder builder, string value)
+        {
+            builder.Append('"');
+            foreach (var ch in value ?? string.Empty)
+            {
+                switch (ch)
+                {
+                    case '\\':
+                        builder.Append("\\\\");
+                        break;
+                    case '"':
+                        builder.Append("\\\"");
+                        break;
+                    case '\b':
+                        builder.Append("\\b");
+                        break;
+                    case '\f':
+                        builder.Append("\\f");
+                        break;
+                    case '\n':
+                        builder.Append("\\n");
+                        break;
+                    case '\r':
+                        builder.Append("\\r");
+                        break;
+                    case '\t':
+                        builder.Append("\\t");
+                        break;
+                    default:
+                        if (char.IsControl(ch))
+                        {
+                            builder.Append("\\u");
+                            builder.Append(((int)ch).ToString("x4", CultureInfo.InvariantCulture));
+                        }
+                        else
+                        {
+                            builder.Append(ch);
+                        }
+
+                        break;
+                }
+            }
+
+            builder.Append('"');
+        }
+#endif
     }
 
     internal sealed class LoaderScanProfileSnapshot

--- a/Services/Diagnostics/LoaderScanTelemetryHub.cs
+++ b/Services/Diagnostics/LoaderScanTelemetryHub.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+#if MLVSCAN_PROFILING
 using System.Text.Json;
+#endif
 
 namespace MLVScan.Services.Diagnostics
 {

--- a/Services/Diagnostics/LoaderScanTelemetryHub.cs
+++ b/Services/Diagnostics/LoaderScanTelemetryHub.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace MLVScan.Services.Diagnostics
+{
+    internal sealed class LoaderScanTelemetryHub
+    {
+        private LoaderScanProfileSnapshot _lastSnapshot;
+
+#if MLVSCAN_PROFILING
+        private LoaderScanProfileSession _session;
+#endif
+
+        public void BeginRun(string runId)
+        {
+#if MLVSCAN_PROFILING
+            _session = new LoaderScanProfileSession(runId);
+#else
+            _ = runId;
+#endif
+            _lastSnapshot = null;
+        }
+
+        public long StartTimestamp()
+        {
+#if MLVSCAN_PROFILING
+            return Stopwatch.GetTimestamp();
+#else
+            return 0;
+#endif
+        }
+
+        public void AddPhaseElapsed(string phaseName, long startTimestamp)
+        {
+#if MLVSCAN_PROFILING
+            if (_session == null || startTimestamp == 0)
+            {
+                return;
+            }
+
+            _session.AddPhaseElapsed(phaseName, Stopwatch.GetTimestamp() - startTimestamp);
+#else
+            _ = phaseName;
+            _ = startTimestamp;
+#endif
+        }
+
+        public void IncrementCounter(string counterName, long delta = 1)
+        {
+#if MLVSCAN_PROFILING
+            if (_session == null)
+            {
+                return;
+            }
+
+            _session.IncrementCounter(counterName, delta);
+#else
+            _ = counterName;
+            _ = delta;
+#endif
+        }
+
+        public void RecordFileSample(string filePath, long startTimestamp, string action, long bytesRead, int findingsCount)
+        {
+#if MLVSCAN_PROFILING
+            if (_session == null || startTimestamp == 0)
+            {
+                return;
+            }
+
+            _session.AddFileSample(filePath, Stopwatch.GetTimestamp() - startTimestamp, action, bytesRead, findingsCount);
+#else
+            _ = filePath;
+            _ = startTimestamp;
+            _ = action;
+            _ = bytesRead;
+            _ = findingsCount;
+#endif
+        }
+
+        public void CompleteRun(int rootsScanned, int candidateFiles, int flaggedFiles)
+        {
+#if MLVSCAN_PROFILING
+            if (_session == null)
+            {
+                return;
+            }
+
+            _session.IncrementCounter("Roots.Scanned", rootsScanned);
+            _session.IncrementCounter("Files.Candidates", candidateFiles);
+            _session.IncrementCounter("Files.Flagged", flaggedFiles);
+            _session.TotalElapsedTicks = Stopwatch.GetTimestamp() - _session.StartTimestamp;
+            _lastSnapshot = _session.ToSnapshot();
+            _session = null;
+#else
+            _ = rootsScanned;
+            _ = candidateFiles;
+            _ = flaggedFiles;
+#endif
+        }
+
+        public LoaderScanProfileSnapshot GetLastSnapshot()
+        {
+            return _lastSnapshot;
+        }
+
+        public string TryWriteArtifact(string diagnosticsDirectory)
+        {
+#if MLVSCAN_PROFILING
+            if (_lastSnapshot == null)
+            {
+                return null;
+            }
+
+            Directory.CreateDirectory(diagnosticsDirectory);
+            var path = Path.Combine(diagnosticsDirectory, $"loader-scan-profile-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json");
+            var json = JsonSerializer.Serialize(_lastSnapshot, new JsonSerializerOptions
+            {
+                WriteIndented = true
+            });
+            File.WriteAllText(path, json);
+            return path;
+#else
+            _ = diagnosticsDirectory;
+            return null;
+#endif
+        }
+    }
+
+    internal sealed class LoaderScanProfileSnapshot
+    {
+        public string RunId { get; set; } = string.Empty;
+
+        public long TotalElapsedTicks { get; set; }
+
+        public IReadOnlyList<LoaderScanPhaseTiming> Phases { get; set; } = Array.Empty<LoaderScanPhaseTiming>();
+
+        public IReadOnlyDictionary<string, long> Counters { get; set; } = new Dictionary<string, long>(StringComparer.Ordinal);
+
+        public IReadOnlyList<LoaderScanFileSample> SlowFiles { get; set; } = Array.Empty<LoaderScanFileSample>();
+    }
+
+    internal sealed class LoaderScanPhaseTiming
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public long ElapsedTicks { get; set; }
+
+        public int Count { get; set; }
+    }
+
+    internal sealed class LoaderScanFileSample
+    {
+        public string FilePath { get; set; } = string.Empty;
+
+        public long ElapsedTicks { get; set; }
+
+        public string Action { get; set; } = string.Empty;
+
+        public long BytesRead { get; set; }
+
+        public int FindingsCount { get; set; }
+    }
+
+#if MLVSCAN_PROFILING
+    internal sealed class LoaderScanProfileSession
+    {
+        private const int MaxSlowFiles = 20;
+
+        private readonly Dictionary<string, LoaderPhaseAccumulator> _phases = new Dictionary<string, LoaderPhaseAccumulator>(StringComparer.Ordinal);
+        private readonly Dictionary<string, long> _counters = new Dictionary<string, long>(StringComparer.Ordinal);
+        private readonly List<LoaderScanFileSample> _files = new List<LoaderScanFileSample>();
+
+        public LoaderScanProfileSession(string runId)
+        {
+            RunId = runId;
+            StartTimestamp = Stopwatch.GetTimestamp();
+        }
+
+        public string RunId { get; }
+
+        public long StartTimestamp { get; }
+
+        public long TotalElapsedTicks { get; set; }
+
+        public void AddPhaseElapsed(string phaseName, long elapsedTicks)
+        {
+            if (!_phases.TryGetValue(phaseName, out var accumulator))
+            {
+                accumulator = new LoaderPhaseAccumulator();
+                _phases[phaseName] = accumulator;
+            }
+
+            accumulator.ElapsedTicks += elapsedTicks;
+            accumulator.Count++;
+        }
+
+        public void IncrementCounter(string counterName, long delta)
+        {
+            _counters[counterName] = _counters.TryGetValue(counterName, out var current)
+                ? current + delta
+                : delta;
+        }
+
+        public void AddFileSample(string filePath, long elapsedTicks, string action, long bytesRead, int findingsCount)
+        {
+            _files.Add(new LoaderScanFileSample
+            {
+                FilePath = filePath,
+                ElapsedTicks = elapsedTicks,
+                Action = action,
+                BytesRead = bytesRead,
+                FindingsCount = findingsCount
+            });
+        }
+
+        public LoaderScanProfileSnapshot ToSnapshot()
+        {
+            return new LoaderScanProfileSnapshot
+            {
+                RunId = RunId,
+                TotalElapsedTicks = TotalElapsedTicks,
+                Phases = _phases
+                    .OrderByDescending(static pair => pair.Value.ElapsedTicks)
+                    .Select(static pair => new LoaderScanPhaseTiming
+                    {
+                        Name = pair.Key,
+                        ElapsedTicks = pair.Value.ElapsedTicks,
+                        Count = pair.Value.Count
+                    })
+                    .ToArray(),
+                Counters = new Dictionary<string, long>(_counters, StringComparer.Ordinal),
+                SlowFiles = _files
+                    .OrderByDescending(static sample => sample.ElapsedTicks)
+                    .Take(MaxSlowFiles)
+                    .ToArray()
+            };
+        }
+    }
+
+    internal sealed class LoaderPhaseAccumulator
+    {
+        public long ElapsedTicks { get; set; }
+
+        public int Count { get; set; }
+    }
+#endif
+}

--- a/Services/PluginDisablerBase.cs
+++ b/Services/PluginDisablerBase.cs
@@ -63,7 +63,7 @@ namespace MLVScan.Services
         protected virtual void OnPluginDisabled(string originalPath, string disabledPath, string hash) { }
 
         /// <summary>
-        /// Disables plugins that meet severity and threshold criteria.
+        /// Disables plugins that meet the configured verdict policy.
         /// </summary>
         /// <param name="scanResults">Dictionary of file paths to their findings.</param>
         /// <param name="forceDisable">If true, disables even if auto-disable is off.</param>
@@ -81,27 +81,23 @@ namespace MLVScan.Services
 
             foreach (var (pluginPath, scanResult) in scanResults)
             {
-                var findings = scanResult?.Findings ?? new List<ScanFinding>();
-                var severeFindings = findings
-                    .Where(f => (int)f.Severity >= (int)Config.MinSeverityForDisable)
-                    .ToList();
-                var shouldBypassThreshold = scanResult?.ThreatVerdict?.ShouldBypassThreshold == true;
+                var verdict = scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
 
-                if (!shouldBypassThreshold && severeFindings.Count == 0)
+                if (verdict.Kind == ThreatVerdictKind.None)
                 {
-                    Logger.Info($"Plugin {Path.GetFileName(pluginPath)} has findings but none meet severity threshold ({Config.MinSeverityForDisable})");
                     continue;
                 }
 
-                if (!forceDisable && !shouldBypassThreshold && severeFindings.Count < Config.SuspiciousThreshold)
+                if (!forceDisable && !ShouldDisable(verdict))
                 {
-                    Logger.Info($"Plugin {Path.GetFileName(pluginPath)} below suspicious threshold");
+                    Logger.Info(
+                        $"Plugin {Path.GetFileName(pluginPath)} matched \"{verdict.Title}\" but blocking for this verdict is disabled in configuration");
                     continue;
                 }
 
                 try
                 {
-                    var info = DisablePlugin(pluginPath, scanResult?.ThreatVerdict);
+                    var info = DisablePlugin(pluginPath, verdict);
                     if (info != null)
                     {
                         disabledPlugins.Add(info);
@@ -115,6 +111,17 @@ namespace MLVScan.Services
             }
 
             return disabledPlugins;
+        }
+
+        private bool ShouldDisable(ThreatVerdictInfo verdict)
+        {
+            return verdict.Kind switch
+            {
+                ThreatVerdictKind.KnownMaliciousSample => Config.BlockKnownThreats,
+                ThreatVerdictKind.KnownMalwareFamily => Config.BlockKnownThreats,
+                ThreatVerdictKind.Suspicious => Config.BlockSuspicious,
+                _ => false
+            };
         }
 
         /// <summary>

--- a/Services/PluginDisablerBase.cs
+++ b/Services/PluginDisablerBase.cs
@@ -66,7 +66,7 @@ namespace MLVScan.Services
         /// Disables plugins that meet the configured verdict policy.
         /// </summary>
         /// <param name="scanResults">Dictionary of file paths to their findings.</param>
-        /// <param name="forceDisable">If true, disables even if auto-disable is off.</param>
+        /// <param name="forceDisable">If true, disables even if auto-disable is off, while still honoring verdict policy toggles.</param>
         public List<DisabledPluginInfo> DisableSuspiciousPlugins(
             Dictionary<string, ScannedPluginResult> scanResults,
             bool forceDisable = false)
@@ -88,7 +88,7 @@ namespace MLVScan.Services
                     continue;
                 }
 
-                if (!forceDisable && !ShouldDisable(verdict))
+                if (!ShouldDisable(verdict))
                 {
                     Logger.Info(
                         $"Plugin {Path.GetFileName(pluginPath)} matched \"{verdict.Title}\" but blocking for this verdict is disabled in configuration");

--- a/Services/PluginDisablerBase.cs
+++ b/Services/PluginDisablerBase.cs
@@ -16,13 +16,20 @@ namespace MLVScan.Services
         public string DisabledPath { get; }
         public string FileHash { get; }
         public ThreatVerdictInfo ThreatVerdict { get; }
+        public ScanStatusInfo ScanStatus { get; }
 
-        public DisabledPluginInfo(string originalPath, string disabledPath, string fileHash, ThreatVerdictInfo threatVerdict)
+        public DisabledPluginInfo(
+            string originalPath,
+            string disabledPath,
+            string fileHash,
+            ThreatVerdictInfo threatVerdict,
+            ScanStatusInfo scanStatus)
         {
             OriginalPath = originalPath;
             DisabledPath = disabledPath;
             FileHash = fileHash;
             ThreatVerdict = threatVerdict ?? new ThreatVerdictInfo();
+            ScanStatus = scanStatus ?? new ScanStatusInfo();
         }
     }
 
@@ -63,7 +70,7 @@ namespace MLVScan.Services
         protected virtual void OnPluginDisabled(string originalPath, string disabledPath, string hash) { }
 
         /// <summary>
-        /// Disables plugins that meet the configured verdict policy.
+        /// Disables plugins that meet the configured verdict or incomplete-scan policy.
         /// </summary>
         /// <param name="scanResults">Dictionary of file paths to their findings.</param>
         /// <param name="forceDisable">If true, disables even if auto-disable is off, while still honoring verdict policy toggles.</param>
@@ -81,23 +88,24 @@ namespace MLVScan.Services
 
             foreach (var (pluginPath, scanResult) in scanResults)
             {
-                var verdict = scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
-
-                if (verdict.Kind == ThreatVerdictKind.None)
+                if (!ScanResultFacts.RequiresAttention(scanResult))
                 {
                     continue;
                 }
 
-                if (!ShouldDisable(verdict))
+                var verdict = scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
+                var scanStatus = scanResult?.ScanStatus ?? new ScanStatusInfo();
+
+                if (!ShouldDisable(scanResult))
                 {
                     Logger.Info(
-                        $"Plugin {Path.GetFileName(pluginPath)} matched \"{verdict.Title}\" but blocking for this verdict is disabled in configuration");
+                        $"Plugin {Path.GetFileName(pluginPath)} requires attention ({GetOutcomeTitle(scanResult)}) but blocking for this outcome is disabled in configuration");
                     continue;
                 }
 
                 try
                 {
-                    var info = DisablePlugin(pluginPath, verdict);
+                    var info = DisablePlugin(pluginPath, verdict, scanStatus);
                     if (info != null)
                     {
                         disabledPlugins.Add(info);
@@ -113,21 +121,49 @@ namespace MLVScan.Services
             return disabledPlugins;
         }
 
-        private bool ShouldDisable(ThreatVerdictInfo verdict)
+        private bool ShouldDisable(ScannedPluginResult scanResult)
         {
+            var verdict = scanResult?.ThreatVerdict ?? new ThreatVerdictInfo();
             return verdict.Kind switch
             {
                 ThreatVerdictKind.KnownMaliciousSample => Config.BlockKnownThreats,
                 ThreatVerdictKind.KnownMalwareFamily => Config.BlockKnownThreats,
                 ThreatVerdictKind.Suspicious => Config.BlockSuspicious,
+                _ => ShouldDisable(scanResult?.ScanStatus ?? new ScanStatusInfo())
+            };
+        }
+
+        private bool ShouldDisable(ScanStatusInfo scanStatus)
+        {
+            return (scanStatus?.Kind ?? ScanStatusKind.Complete) switch
+            {
+                ScanStatusKind.RequiresReview => Config.BlockIncompleteScans,
                 _ => false
             };
+        }
+
+        private static string GetOutcomeTitle(ScannedPluginResult scanResult)
+        {
+            if (ScanResultFacts.HasThreatVerdict(scanResult))
+            {
+                return scanResult.ThreatVerdict.Title;
+            }
+
+            if (ScanResultFacts.RequiresManualReview(scanResult))
+            {
+                return scanResult.ScanStatus.Title;
+            }
+
+            return "No action required";
         }
 
         /// <summary>
         /// Disables a single plugin by renaming it.
         /// </summary>
-        protected virtual DisabledPluginInfo DisablePlugin(string pluginPath, ThreatVerdictInfo threatVerdict)
+        protected virtual DisabledPluginInfo DisablePlugin(
+            string pluginPath,
+            ThreatVerdictInfo threatVerdict,
+            ScanStatusInfo scanStatus)
         {
             var fileHash = HashUtility.CalculateFileHash(pluginPath);
             var disabledPath = GetDisabledPath(pluginPath);
@@ -142,7 +178,7 @@ namespace MLVScan.Services
             File.Move(pluginPath, disabledPath);
 
             Logger.Warning($"BLOCKED: {Path.GetFileName(pluginPath)}");
-            return new DisabledPluginInfo(pluginPath, disabledPath, fileHash, threatVerdict);
+            return new DisabledPluginInfo(pluginPath, disabledPath, fileHash, threatVerdict, scanStatus);
         }
     }
 }

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using MLVScan.Abstractions;
 using MLVScan.Models;
@@ -218,23 +219,38 @@ namespace MLVScan.Services
                 return;
             }
 
-            if (probe.Stream.CanSeek && probe.Stream.Length > MaxAssemblyScanBytes)
+            var isOversized = probe.Stream.CanSeek && probe.Stream.Length > MaxAssemblyScanBytes;
+            var bytesRead = 0L;
+            byte[] assemblyBytes = null;
+            string hash;
+
+            if (isOversized)
             {
                 Logger.Warning(
-                    $"Skipping {fileName} because it is larger than the loader scan limit of {MaxAssemblyScanBytes / (1024 * 1024)} MB.");
+                    $"Flagging {fileName} because it exceeds the loader scan limit of {MaxAssemblyScanBytes / (1024 * 1024)} MB and cannot be fully analyzed in memory.");
                 _telemetry.IncrementCounter("Files.TooLarge");
-                _telemetry.RecordFileSample(filePath, fileStart, "skip:too-large", 0, 0);
-                return;
+                bytesRead = probe.Stream.CanSeek ? probe.Stream.Length : 0L;
+                if (bytesRead > 0)
+                {
+                    _telemetry.IncrementCounter("Bytes.Read", bytesRead);
+                }
+
+                var hashStart = _telemetry.StartTimestamp();
+                hash = CalculateStreamHash(probe.Stream);
+                _telemetry.AddPhaseElapsed("Hash.CalculateSha256", hashStart);
             }
+            else
+            {
+                var readStart = _telemetry.StartTimestamp();
+                assemblyBytes = ReadFileBytes(probe.Stream);
+                _telemetry.AddPhaseElapsed("File.ReadBytes", readStart);
+                bytesRead = assemblyBytes.Length;
+                _telemetry.IncrementCounter("Bytes.Read", bytesRead);
 
-            var readStart = _telemetry.StartTimestamp();
-            var assemblyBytes = ReadFileBytes(probe.Stream);
-            _telemetry.AddPhaseElapsed("File.ReadBytes", readStart);
-            _telemetry.IncrementCounter("Bytes.Read", assemblyBytes.Length);
-
-            var hashStart = _telemetry.StartTimestamp();
-            var hash = HashUtility.CalculateBytesHash(assemblyBytes);
-            _telemetry.AddPhaseElapsed("Hash.CalculateSha256", hashStart);
+                var hashStart = _telemetry.StartTimestamp();
+                hash = HashUtility.CalculateBytesHash(assemblyBytes);
+                _telemetry.AddPhaseElapsed("Hash.CalculateSha256", hashStart);
+            }
 
             if (IsExactSelfCopy(hash))
             {
@@ -251,7 +267,7 @@ namespace MLVScan.Services
             if (Config.EnableScanCache &&
                 TryReuseByHashCache(hash, probe, filePath, resolverFingerprint, results))
             {
-                _telemetry.RecordFileSample(filePath, fileStart, "cache-hit:hash", assemblyBytes.Length, 0);
+                _telemetry.RecordFileSample(filePath, fileStart, "cache-hit:hash", bytesRead, 0);
                 return;
             }
 
@@ -260,7 +276,16 @@ namespace MLVScan.Services
             {
                 UpsertCacheEntry(probe, hash, resolverFingerprint, exactHashResult);
                 RegisterFlaggedResultIfNeeded(fileName, exactHashResult, results);
-                _telemetry.RecordFileSample(filePath, fileStart, "hash-only-known-sample", assemblyBytes.Length, 0);
+                _telemetry.RecordFileSample(filePath, fileStart, "hash-only-known-sample", bytesRead, 0);
+                return;
+            }
+
+            if (isOversized)
+            {
+                var oversizedResult = CreateOversizedAssemblyResult(filePath, hash, bytesRead);
+                UpsertCacheEntry(probe, hash, resolverFingerprint, oversizedResult);
+                RegisterFlaggedResultIfNeeded(fileName, oversizedResult, results);
+                _telemetry.RecordFileSample(filePath, fileStart, "oversized:flagged", bytesRead, oversizedResult.Findings.Count);
                 return;
             }
 
@@ -277,7 +302,7 @@ namespace MLVScan.Services
             UpsertCacheEntry(probe, hash, resolverFingerprint, scannedResult);
 
             RegisterFlaggedResultIfNeeded(fileName, scannedResult, results);
-            _telemetry.RecordFileSample(filePath, fileStart, "scan", assemblyBytes.Length, actualFindings.Count);
+            _telemetry.RecordFileSample(filePath, fileStart, "scan", bytesRead, actualFindings.Count);
         }
 
         private bool TryReuseByPathCache(
@@ -423,6 +448,39 @@ namespace MLVScan.Services
             });
         }
 
+        private static ScannedPluginResult CreateOversizedAssemblyResult(string filePath, string fileHash, long fileSizeBytes)
+        {
+            var limitMb = MaxAssemblyScanBytes / (1024 * 1024);
+            var sizeMb = fileSizeBytes > 0
+                ? Math.Ceiling(fileSizeBytes / (1024d * 1024d))
+                : 0d;
+            var findings = new List<ScanFinding>
+            {
+                new ScanFinding(
+                    "Loader scan preflight",
+                    $"Assembly exceeds the loader scan limit ({sizeMb:0.#} MB > {limitMb} MB), so full IL analysis was skipped and the file is being treated as suspicious until reviewed.",
+                    Severity.High)
+                {
+                    RuleId = "OversizedAssembly"
+                }
+            };
+
+            return new ScannedPluginResult
+            {
+                FilePath = filePath ?? string.Empty,
+                FileHash = fileHash ?? string.Empty,
+                Findings = findings,
+                ThreatVerdict = new ThreatVerdictInfo
+                {
+                    Kind = ThreatVerdictKind.Suspicious,
+                    Title = "Oversized assembly requires manual review",
+                    Summary = "This file exceeds the loader scan size limit, so full IL analysis was skipped and it is being treated as suspicious until reviewed.",
+                    Confidence = 0d,
+                    ShouldBypassThreshold = false
+                }
+            };
+        }
+
         private string BuildResolverCatalog(IReadOnlyCollection<string> effectiveRoots)
         {
             if (_resolverCatalogProvider == null)
@@ -503,6 +561,14 @@ namespace MLVScan.Services
             using var memory = new MemoryStream(stream.CanSeek ? (int)stream.Length : 0);
             stream.CopyTo(memory);
             return memory.ToArray();
+        }
+
+        private static string CalculateStreamHash(FileStream stream)
+        {
+            stream.Position = 0;
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(stream);
+            return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
         }
 
         private static IScanCacheStore CreateDefaultCacheStore(IPlatformEnvironment environment)

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -2,14 +2,20 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using MLVScan.Abstractions;
 using MLVScan.Models;
+using MLVScan.Models.Rules;
+using MLVScan.Services.Caching;
+using MLVScan.Services.Diagnostics;
+using MLVScan.Services.Resolution;
+using MLVScan.Services.Scope;
 
 namespace MLVScan.Services
 {
     /// <summary>
     /// Abstract base class for plugin/mod scanning across platforms.
-    /// Contains shared scanning logic, with platform-specific details 
+    /// Contains shared scanning logic, with platform-specific details
     /// delegated to derived classes.
     /// </summary>
     public abstract class PluginScannerBase
@@ -18,25 +24,41 @@ namespace MLVScan.Services
         protected readonly IAssemblyResolverProvider ResolverProvider;
         protected readonly MLVScanConfig Config;
         protected readonly IConfigManager ConfigManager;
+        protected readonly IPlatformEnvironment Environment;
         protected readonly AssemblyScanner AssemblyScanner;
         protected readonly ThreatVerdictBuilder ThreatVerdictBuilder;
+
+        private readonly IFileIdentityProvider _fileIdentityProvider;
+        private readonly IScanCacheStore _cacheStore;
+        private readonly IResolverCatalogProvider _resolverCatalogProvider;
+        private readonly LoaderScanTelemetryHub _telemetry;
+        private readonly TargetAssemblyScopeFilter _scopeFilter = new TargetAssemblyScopeFilter();
+        private readonly string _scannerFingerprint;
         private readonly string _selfAssemblyHash;
 
         protected PluginScannerBase(
             IScanLogger logger,
             IAssemblyResolverProvider resolverProvider,
             MLVScanConfig config,
-            IConfigManager configManager)
+            IConfigManager configManager,
+            IPlatformEnvironment environment)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             ResolverProvider = resolverProvider ?? throw new ArgumentNullException(nameof(resolverProvider));
             Config = config ?? throw new ArgumentNullException(nameof(config));
             ConfigManager = configManager ?? throw new ArgumentNullException(nameof(configManager));
+            Environment = environment ?? throw new ArgumentNullException(nameof(environment));
 
-            var rules = RuleFactory.CreateDefaultRules();
+            _telemetry = new LoaderScanTelemetryHub();
+            _fileIdentityProvider = new CrossPlatformFileIdentityProvider();
+            _cacheStore = CreateDefaultCacheStore(environment);
+            _resolverCatalogProvider = resolverProvider as IResolverCatalogProvider;
+
+            var rules = RuleFactory.CreateDefaultRules().ToArray();
             AssemblyScanner = new AssemblyScanner(rules, Config.Scan, ResolverProvider);
             ThreatVerdictBuilder = new ThreatVerdictBuilder();
-            _selfAssemblyHash = GetSelfAssemblyHash();
+            _scannerFingerprint = ComputeScannerFingerprint(Config.Scan, rules);
+            _selfAssemblyHash = GetSelfAssemblyHash(environment.SelfAssemblyPath);
         }
 
         /// <summary>
@@ -60,7 +82,7 @@ namespace MLVScan.Services
         /// <param name="forceScanning">If true, scans even if auto-scan is disabled.</param>
         public Dictionary<string, ScannedPluginResult> ScanAllPlugins(bool forceScanning = false)
         {
-            var results = new Dictionary<string, ScannedPluginResult>();
+            var results = new Dictionary<string, ScannedPluginResult>(StringComparer.OrdinalIgnoreCase);
 
             if (!forceScanning && !Config.EnableAutoScan)
             {
@@ -68,95 +90,289 @@ namespace MLVScan.Services
                 return results;
             }
 
-            foreach (var directory in GetScanDirectories())
-            {
-                if (!Directory.Exists(directory))
-                {
-                    Logger.Warning($"Directory not found: {directory}");
-                    continue;
-                }
+            _telemetry.BeginRun($"{Environment.PlatformName}-{DateTime.UtcNow:yyyyMMdd-HHmmss}");
 
-                ScanDirectory(directory, results);
+            var rawRoots = GetScanDirectories().ToArray();
+            foreach (var directory in rawRoots.Where(static directory => !Directory.Exists(directory)))
+            {
+                Logger.Warning($"Directory not found: {directory}");
             }
 
-            OnScanComplete(results);
-            return results;
-        }
+            var scopeStart = _telemetry.StartTimestamp();
+            var effectiveRoots = _scopeFilter.BuildEffectiveRoots(rawRoots, Config);
+            _telemetry.AddPhaseElapsed("Scope.BuildEffectiveRoots", scopeStart);
 
-        /// <summary>
-        /// Scans a single directory for malicious plugins.
-        /// </summary>
-        protected virtual void ScanDirectory(string directoryPath, Dictionary<string, ScannedPluginResult> results)
-        {
-            var pluginFiles = Directory.GetFiles(directoryPath, "*.dll", SearchOption.AllDirectories);
-            Logger.Info($"Found {pluginFiles.Length} plugin files in {directoryPath}");
+            var resolverFingerprint = BuildResolverCatalog(effectiveRoots);
+            var candidateFiles = effectiveRoots
+                .SelectMany(EnumerateCandidateFiles)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
 
-            foreach (var pluginFile in pluginFiles)
+            var activeCanonicalPaths = new HashSet<string>(GetPathComparer());
+            var processedCanonicalPaths = new HashSet<string>(GetPathComparer());
+
+            foreach (var pluginFile in candidateFiles)
             {
                 try
                 {
-                    ScanSingleFile(pluginFile, results);
+                    ScanSingleFile(
+                        pluginFile,
+                        effectiveRoots,
+                        results,
+                        activeCanonicalPaths,
+                        processedCanonicalPaths,
+                        resolverFingerprint);
                 }
                 catch (Exception ex)
                 {
                     Logger.Error($"Error scanning {Path.GetFileName(pluginFile)}: {ex.Message}");
                 }
             }
+
+            if (Config.EnableScanCache)
+            {
+                _cacheStore.PruneMissingEntries(activeCanonicalPaths);
+            }
+
+            OnScanComplete(results);
+            _telemetry.CompleteRun(effectiveRoots.Count, candidateFiles.Length, results.Count);
+
+            var artifactPath = _telemetry.TryWriteArtifact(Path.Combine(Environment.DataDirectory, "Diagnostics"));
+            if (!string.IsNullOrWhiteSpace(artifactPath))
+            {
+                Logger.Debug($"Wrote loader profile artifact: {artifactPath}");
+            }
+
+            return results;
+        }
+
+        protected virtual IEnumerable<string> EnumerateCandidateFiles(string directoryPath)
+        {
+            Logger.Info($"Scanning directory: {directoryPath}");
+            return Directory.EnumerateFiles(directoryPath, "*.dll", SearchOption.AllDirectories);
         }
 
         /// <summary>
         /// Scans a single file and adds results if suspicious.
         /// </summary>
-        protected virtual void ScanSingleFile(string filePath, Dictionary<string, ScannedPluginResult> results)
+        protected virtual void ScanSingleFile(
+            string filePath,
+            IReadOnlyCollection<string> effectiveRoots,
+            Dictionary<string, ScannedPluginResult> results,
+            ISet<string> activeCanonicalPaths,
+            ISet<string> processedCanonicalPaths,
+            string resolverFingerprint)
         {
+            var fileStart = _telemetry.StartTimestamp();
             var fileName = Path.GetFileName(filePath);
-            var hash = HashUtility.CalculateFileHash(filePath);
 
-            // Skip ourselves
-            if (IsSelfAssembly(filePath) || IsExactSelfCopy(hash))
+            using var probe = _fileIdentityProvider.OpenProbe(filePath);
+            if (!_scopeFilter.IsTargetAssembly(probe.CanonicalPath, effectiveRoots, Config))
+            {
+                _telemetry.IncrementCounter("Files.OutOfScope");
+                return;
+            }
+
+            activeCanonicalPaths.Add(probe.CanonicalPath);
+            if (!processedCanonicalPaths.Add(probe.CanonicalPath))
+            {
+                _telemetry.IncrementCounter("Files.DuplicateCanonicalPath");
+                return;
+            }
+
+            if (IsSelfAssembly(probe.CanonicalPath))
             {
                 Logger.Debug($"Skipping self: {fileName}");
+                _telemetry.IncrementCounter("Files.Self");
                 return;
             }
 
-            // Skip whitelisted plugins
-            if (ConfigManager.IsHashWhitelisted(hash))
+            if (Config.EnableScanCache &&
+                TryReuseByPathCache(probe, filePath, resolverFingerprint, results))
             {
-                Logger.Debug($"Skipping whitelisted: {fileName}");
+                _telemetry.RecordFileSample(filePath, fileStart, "cache-hit:path", 0, 0);
                 return;
             }
 
-            var findings = AssemblyScanner.Scan(filePath).ToList();
+            var readStart = _telemetry.StartTimestamp();
+            var assemblyBytes = ReadFileBytes(probe.Stream);
+            _telemetry.AddPhaseElapsed("File.ReadBytes", readStart);
+            _telemetry.IncrementCounter("Bytes.Read", assemblyBytes.Length);
 
-            // Filter out placeholder findings
+            var hashStart = _telemetry.StartTimestamp();
+            var hash = HashUtility.CalculateBytesHash(assemblyBytes);
+            _telemetry.AddPhaseElapsed("Hash.CalculateSha256", hashStart);
+
+            if (IsExactSelfCopy(hash))
+            {
+                Logger.Debug($"Skipping self copy: {fileName}");
+                _telemetry.IncrementCounter("Files.SelfCopy");
+                return;
+            }
+
+            if (Config.EnableScanCache &&
+                TryReuseByHashCache(hash, probe, filePath, resolverFingerprint, results))
+            {
+                _telemetry.RecordFileSample(filePath, fileStart, "cache-hit:hash", assemblyBytes.Length, 0);
+                return;
+            }
+
+            var exactHashResult = ThreatVerdictBuilder.Build(filePath, hash, new List<ScanFinding>());
+            if (exactHashResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMaliciousSample)
+            {
+                UpsertCacheEntry(probe, hash, resolverFingerprint, exactHashResult);
+                RegisterFlaggedResultIfNeeded(fileName, exactHashResult, results);
+                _telemetry.RecordFileSample(filePath, fileStart, "hash-only-known-sample", assemblyBytes.Length, 0);
+                return;
+            }
+
+            var scanStart = _telemetry.StartTimestamp();
+            using var assemblyStream = new MemoryStream(assemblyBytes, writable: false);
+            var findings = AssemblyScanner.Scan(assemblyStream, filePath).ToList();
+            _telemetry.AddPhaseElapsed("Scan.Assembly", scanStart);
+
             var actualFindings = findings
-                .Where(f => f.Location != "Assembly scanning")
+                .Where(static finding => finding.Location != "Assembly scanning")
                 .ToList();
 
             var scannedResult = ThreatVerdictBuilder.Build(filePath, hash, actualFindings);
+            UpsertCacheEntry(probe, hash, resolverFingerprint, scannedResult);
 
-            if (scannedResult.ThreatVerdict.Kind != ThreatVerdictKind.None)
+            RegisterFlaggedResultIfNeeded(fileName, scannedResult, results);
+            _telemetry.RecordFileSample(filePath, fileStart, "scan", assemblyBytes.Length, actualFindings.Count);
+        }
+
+        private bool TryReuseByPathCache(
+            FileProbe probe,
+            string filePath,
+            string resolverFingerprint,
+            Dictionary<string, ScannedPluginResult> results)
+        {
+            var entry = _cacheStore.TryGetByPath(probe.CanonicalPath);
+            if (entry == null)
             {
-                results[filePath] = scannedResult;
+                _telemetry.IncrementCounter("Cache.PathMiss");
+                return false;
+            }
 
-                if (scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMaliciousSample ||
-                    scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMalwareFamily)
+            if (!entry.CanReuseStrictly(probe, _scannerFingerprint, resolverFingerprint, _cacheStore.CanTrustCleanEntries))
+            {
+                _telemetry.IncrementCounter("Cache.PathRejected");
+                return false;
+            }
+
+            _telemetry.IncrementCounter("Cache.PathHit");
+            RegisterFlaggedResultIfNeeded(Path.GetFileName(filePath), entry.CloneResultForPath(filePath), results);
+            return true;
+        }
+
+        private bool TryReuseByHashCache(
+            string hash,
+            FileProbe probe,
+            string filePath,
+            string resolverFingerprint,
+            Dictionary<string, ScannedPluginResult> results)
+        {
+            var entry = _cacheStore.TryGetByHash(hash);
+            if (entry == null)
+            {
+                _telemetry.IncrementCounter("Cache.HashMiss");
+                return false;
+            }
+
+            if (!string.Equals(entry.ScannerFingerprint, _scannerFingerprint, StringComparison.Ordinal) ||
+                !string.Equals(entry.ResolverFingerprint, resolverFingerprint, StringComparison.Ordinal))
+            {
+                _telemetry.IncrementCounter("Cache.HashRejected");
+                return false;
+            }
+
+            if (entry.Result?.ThreatVerdict?.Kind == ThreatVerdictKind.None &&
+                !_cacheStore.CanTrustCleanEntries)
+            {
+                _telemetry.IncrementCounter("Cache.HashRejected");
+                return false;
+            }
+
+            var clonedResult = entry.CloneResultForPath(filePath);
+            UpsertCacheEntry(probe, hash, resolverFingerprint, clonedResult);
+            _telemetry.IncrementCounter("Cache.HashHit");
+            RegisterFlaggedResultIfNeeded(Path.GetFileName(filePath), clonedResult, results);
+            return true;
+        }
+
+        private void RegisterFlaggedResultIfNeeded(
+            string fileName,
+            ScannedPluginResult scannedResult,
+            Dictionary<string, ScannedPluginResult> results)
+        {
+            if (scannedResult == null)
+            {
+                return;
+            }
+
+            if (ConfigManager.IsHashWhitelisted(scannedResult.FileHash))
+            {
+                Logger.Debug($"Skipping whitelisted: {fileName}");
+                _telemetry.IncrementCounter("Files.Whitelisted");
+                return;
+            }
+
+            if (scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.None)
+            {
+                return;
+            }
+
+            results[scannedResult.FilePath] = scannedResult;
+            if (scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMaliciousSample ||
+                scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMalwareFamily)
+            {
+                var familyName = scannedResult.ThreatVerdict.PrimaryFamily?.DisplayName;
+                if (!string.IsNullOrWhiteSpace(familyName))
                 {
-                    var familyName = scannedResult.ThreatVerdict.PrimaryFamily?.DisplayName;
-                    if (!string.IsNullOrWhiteSpace(familyName))
-                    {
-                        Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}: {familyName}");
-                    }
-                    else
-                    {
-                        Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}");
-                    }
+                    Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}: {familyName}");
                 }
                 else
                 {
-                    Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
+                    Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}");
                 }
+
+                return;
             }
+
+            Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
+        }
+
+        private void UpsertCacheEntry(FileProbe probe, string hash, string resolverFingerprint, ScannedPluginResult result)
+        {
+            if (!Config.EnableScanCache)
+            {
+                return;
+            }
+
+            _cacheStore.Upsert(new ScanCacheEntry
+            {
+                CanonicalPath = probe.CanonicalPath,
+                RealPath = probe.CanonicalPath,
+                FileIdentity = probe.Identity,
+                Sha256 = hash,
+                ScannerFingerprint = _scannerFingerprint,
+                ResolverFingerprint = resolverFingerprint,
+                Result = result
+            });
+        }
+
+        private string BuildResolverCatalog(IReadOnlyCollection<string> effectiveRoots)
+        {
+            if (_resolverCatalogProvider == null)
+            {
+                return "resolver-provider-unavailable";
+            }
+
+            var start = _telemetry.StartTimestamp();
+            _resolverCatalogProvider.BuildCatalog(effectiveRoots);
+            _telemetry.AddPhaseElapsed("Resolver.BuildCatalog", start);
+            return _resolverCatalogProvider.ContextFingerprint;
         }
 
         private bool IsExactSelfCopy(string hash)
@@ -165,22 +381,71 @@ namespace MLVScan.Services
                    _selfAssemblyHash.Equals(hash, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static string GetSelfAssemblyHash()
+        private static string GetSelfAssemblyHash(string selfAssemblyPath)
         {
             try
             {
-                var selfPath = typeof(PluginScannerBase).Assembly.Location;
-                if (string.IsNullOrWhiteSpace(selfPath) || !File.Exists(selfPath))
+                if (string.IsNullOrWhiteSpace(selfAssemblyPath) || !File.Exists(selfAssemblyPath))
                 {
                     return string.Empty;
                 }
 
-                return HashUtility.CalculateFileHash(selfPath);
+                return HashUtility.CalculateFileHash(selfAssemblyPath);
             }
             catch
             {
                 return string.Empty;
             }
+        }
+
+        private static byte[] ReadFileBytes(FileStream stream)
+        {
+            stream.Position = 0;
+            using var memory = new MemoryStream(stream.CanSeek ? (int)stream.Length : 0);
+            stream.CopyTo(memory);
+            return memory.ToArray();
+        }
+
+        private static IScanCacheStore CreateDefaultCacheStore(IPlatformEnvironment environment)
+        {
+            var cacheDirectory = Path.Combine(environment.DataDirectory, "Cache");
+            return new SecureScanCacheStore(cacheDirectory, new ScanCacheSigner(cacheDirectory));
+        }
+
+        private static string ComputeScannerFingerprint(ScanConfig config, IReadOnlyCollection<IScanRule> rules)
+        {
+            var parts = new List<string>
+            {
+                PlatformConstants.PlatformName,
+                PlatformConstants.PlatformVersion,
+                MLVScanVersions.CoreVersion,
+                MLVScanVersions.SchemaVersion.ToString(),
+                $"EnableMultiSignalDetection={config.EnableMultiSignalDetection}",
+                $"AnalyzeExceptionHandlers={config.AnalyzeExceptionHandlers}",
+                $"AnalyzeLocalVariables={config.AnalyzeLocalVariables}",
+                $"AnalyzePropertyAccessors={config.AnalyzePropertyAccessors}",
+                $"DetectAssemblyMetadata={config.DetectAssemblyMetadata}",
+                $"EnableCrossMethodAnalysis={config.EnableCrossMethodAnalysis}",
+                $"MaxCallChainDepth={config.MaxCallChainDepth}",
+                $"EnableReturnValueTracking={config.EnableReturnValueTracking}",
+                $"EnableRecursiveResourceScanning={config.EnableRecursiveResourceScanning}",
+                $"MaxRecursiveResourceSizeMB={config.MaxRecursiveResourceSizeMB}",
+                $"MinimumEncodedStringLength={config.MinimumEncodedStringLength}"
+            };
+
+            parts.AddRange(rules
+                .OrderBy(rule => rule.RuleId, StringComparer.Ordinal)
+                .ThenBy(rule => rule.GetType().FullName, StringComparer.Ordinal)
+                .Select(rule => $"{rule.RuleId}|{rule.Severity}|{rule.GetType().FullName}"));
+
+            return HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(string.Join("\n", parts)));
+        }
+
+        private static StringComparer GetPathComparer()
+        {
+            return RuntimeInformationHelper.IsWindows
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
         }
     }
 }

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -243,6 +243,11 @@ namespace MLVScan.Services
                 return;
             }
 
+            if (IsHashWhitelisted(fileName, hash))
+            {
+                return;
+            }
+
             if (Config.EnableScanCache &&
                 TryReuseByHashCache(hash, probe, filePath, resolverFingerprint, results))
             {
@@ -356,10 +361,8 @@ namespace MLVScan.Services
                 return;
             }
 
-            if (ConfigManager.IsHashWhitelisted(scannedResult.FileHash))
+            if (IsHashWhitelisted(fileName, scannedResult.FileHash))
             {
-                Logger.Debug($"Skipping whitelisted: {fileName}");
-                _telemetry.IncrementCounter("Files.Whitelisted");
                 return;
             }
 
@@ -386,6 +389,18 @@ namespace MLVScan.Services
             }
 
             Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
+        }
+
+        private bool IsHashWhitelisted(string fileName, string fileHash)
+        {
+            if (!ConfigManager.IsHashWhitelisted(fileHash))
+            {
+                return false;
+            }
+
+            Logger.Debug($"Skipping whitelisted: {fileName}");
+            _telemetry.IncrementCounter("Files.Whitelisted");
+            return true;
         }
 
         private void UpsertCacheEntry(FileProbe probe, string hash, string resolverFingerprint, ScannedPluginResult result)

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -178,7 +178,7 @@ namespace MLVScan.Services
         }
 
         /// <summary>
-        /// Scans a single file and adds results if suspicious.
+        /// Scans a single file and adds results when the file requires user attention.
         /// </summary>
         protected virtual void ScanSingleFile(
             string filePath,
@@ -227,7 +227,7 @@ namespace MLVScan.Services
             if (isOversized)
             {
                 Logger.Warning(
-                    $"Flagging {fileName} because it exceeds the loader scan limit of {MaxAssemblyScanBytes / (1024 * 1024)} MB and cannot be fully analyzed in memory.");
+                    $"Manual review required for {fileName}: it exceeds the loader scan limit of {MaxAssemblyScanBytes / (1024 * 1024)} MB and cannot be fully analyzed in memory.");
                 _telemetry.IncrementCounter("Files.TooLarge");
                 bytesRead = probe.Stream.CanSeek ? probe.Stream.Length : 0L;
                 if (bytesRead > 0)
@@ -275,7 +275,7 @@ namespace MLVScan.Services
             if (exactHashResult.ThreatVerdict.Kind == ThreatVerdictKind.KnownMaliciousSample)
             {
                 UpsertCacheEntry(probe, hash, resolverFingerprint, exactHashResult);
-                RegisterFlaggedResultIfNeeded(fileName, exactHashResult, results);
+                RegisterResultIfNeeded(fileName, exactHashResult, results);
                 _telemetry.RecordFileSample(filePath, fileStart, "hash-only-known-sample", bytesRead, 0);
                 return;
             }
@@ -284,8 +284,8 @@ namespace MLVScan.Services
             {
                 var oversizedResult = CreateOversizedAssemblyResult(filePath, hash, bytesRead);
                 UpsertCacheEntry(probe, hash, resolverFingerprint, oversizedResult);
-                RegisterFlaggedResultIfNeeded(fileName, oversizedResult, results);
-                _telemetry.RecordFileSample(filePath, fileStart, "oversized:flagged", bytesRead, oversizedResult.Findings.Count);
+                RegisterResultIfNeeded(fileName, oversizedResult, results);
+                _telemetry.RecordFileSample(filePath, fileStart, "oversized:review-required", bytesRead, oversizedResult.Findings.Count);
                 return;
             }
 
@@ -301,7 +301,7 @@ namespace MLVScan.Services
             var scannedResult = ThreatVerdictBuilder.Build(filePath, hash, actualFindings);
             UpsertCacheEntry(probe, hash, resolverFingerprint, scannedResult);
 
-            RegisterFlaggedResultIfNeeded(fileName, scannedResult, results);
+            RegisterResultIfNeeded(fileName, scannedResult, results);
             _telemetry.RecordFileSample(filePath, fileStart, "scan", bytesRead, actualFindings.Count);
         }
 
@@ -331,7 +331,7 @@ namespace MLVScan.Services
             }
 
             _telemetry.IncrementCounter("Cache.PathHit");
-            RegisterFlaggedResultIfNeeded(Path.GetFileName(filePath), entry.CloneResultForPath(filePath), results);
+            RegisterResultIfNeeded(Path.GetFileName(filePath), entry.CloneResultForPath(filePath), results);
             return true;
         }
 
@@ -362,7 +362,7 @@ namespace MLVScan.Services
                 return false;
             }
 
-            if (entry.Result?.ThreatVerdict?.Kind == ThreatVerdictKind.None &&
+            if (!ScanResultFacts.HasThreatVerdict(entry.Result) &&
                 !cacheStore.CanTrustCleanEntries)
             {
                 _telemetry.IncrementCounter("Cache.HashRejected");
@@ -372,11 +372,11 @@ namespace MLVScan.Services
             var clonedResult = entry.CloneResultForPath(filePath);
             UpsertCacheEntry(probe, hash, resolverFingerprint, clonedResult);
             _telemetry.IncrementCounter("Cache.HashHit");
-            RegisterFlaggedResultIfNeeded(Path.GetFileName(filePath), clonedResult, results);
+            RegisterResultIfNeeded(Path.GetFileName(filePath), clonedResult, results);
             return true;
         }
 
-        private void RegisterFlaggedResultIfNeeded(
+        private void RegisterResultIfNeeded(
             string fileName,
             ScannedPluginResult scannedResult,
             Dictionary<string, ScannedPluginResult> results)
@@ -391,7 +391,7 @@ namespace MLVScan.Services
                 return;
             }
 
-            if (scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.None)
+            if (!ScanResultFacts.RequiresAttention(scannedResult))
             {
                 return;
             }
@@ -413,7 +413,13 @@ namespace MLVScan.Services
                 return;
             }
 
-            Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
+            if (scannedResult.ThreatVerdict.Kind == ThreatVerdictKind.Suspicious)
+            {
+                Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
+                return;
+            }
+
+            Logger.Warning($"Manual review required for {fileName} - {scannedResult.ScanStatus.Title}");
         }
 
         private bool IsHashWhitelisted(string fileName, string fileHash)
@@ -458,8 +464,8 @@ namespace MLVScan.Services
             {
                 new ScanFinding(
                     "Loader scan preflight",
-                    $"Assembly exceeds the loader scan limit ({sizeMb:0.#} MB > {limitMb} MB), so full IL analysis was skipped and the file is being treated as suspicious until reviewed.",
-                    Severity.High)
+                    $"Assembly exceeds the loader scan limit ({sizeMb:0.#} MB > {limitMb} MB). SHA-256 and exact known-malicious sample checks still ran, but full IL analysis was skipped and the file requires manual review.",
+                    Severity.Medium)
                 {
                     RuleId = "OversizedAssembly"
                 }
@@ -472,11 +478,17 @@ namespace MLVScan.Services
                 Findings = findings,
                 ThreatVerdict = new ThreatVerdictInfo
                 {
-                    Kind = ThreatVerdictKind.Suspicious,
-                    Title = "Oversized assembly requires manual review",
-                    Summary = "This file exceeds the loader scan size limit, so full IL analysis was skipped and it is being treated as suspicious until reviewed.",
+                    Kind = ThreatVerdictKind.None,
+                    Title = "No threat verdict",
+                    Summary = "No retained malicious verdict was produced before the loader hit a scan-completeness limit.",
                     Confidence = 0d,
                     ShouldBypassThreshold = false
+                },
+                ScanStatus = new ScanStatusInfo
+                {
+                    Kind = ScanStatusKind.RequiresReview,
+                    Title = "Manual review required",
+                    Summary = $"This file exceeds the loader scan size limit ({limitMb} MB). MLVScan calculated its SHA-256 hash and checked exact known-malicious sample matches, but full IL analysis was skipped to avoid loading the entire assembly into memory."
                 }
             };
         }

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -27,6 +27,7 @@ namespace MLVScan.Services
         protected readonly IPlatformEnvironment Environment;
         protected readonly AssemblyScanner AssemblyScanner;
         protected readonly ThreatVerdictBuilder ThreatVerdictBuilder;
+        private const long MaxAssemblyScanBytes = 256L * 1024 * 1024;
 
         private readonly IFileIdentityProvider _fileIdentityProvider;
         private readonly IScanCacheStore _cacheStore;
@@ -103,13 +104,14 @@ namespace MLVScan.Services
             _telemetry.AddPhaseElapsed("Scope.BuildEffectiveRoots", scopeStart);
 
             var resolverFingerprint = BuildResolverCatalog(effectiveRoots);
+            var pathComparer = GetPathComparer();
             var candidateFiles = effectiveRoots
                 .SelectMany(EnumerateCandidateFiles)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Distinct(pathComparer)
                 .ToArray();
 
-            var activeCanonicalPaths = new HashSet<string>(GetPathComparer());
-            var processedCanonicalPaths = new HashSet<string>(GetPathComparer());
+            var activeCanonicalPaths = new HashSet<string>(pathComparer);
+            var processedCanonicalPaths = new HashSet<string>(pathComparer);
 
             foreach (var pluginFile in candidateFiles)
             {
@@ -191,6 +193,15 @@ namespace MLVScan.Services
                 TryReuseByPathCache(probe, filePath, resolverFingerprint, results))
             {
                 _telemetry.RecordFileSample(filePath, fileStart, "cache-hit:path", 0, 0);
+                return;
+            }
+
+            if (probe.Stream.CanSeek && probe.Stream.Length > MaxAssemblyScanBytes)
+            {
+                Logger.Warning(
+                    $"Skipping {fileName} because it is larger than the loader scan limit of {MaxAssemblyScanBytes / (1024 * 1024)} MB.");
+                _telemetry.IncrementCounter("Files.TooLarge");
+                _telemetry.RecordFileSample(filePath, fileStart, "skip:too-large", 0, 0);
                 return;
             }
 
@@ -353,7 +364,7 @@ namespace MLVScan.Services
             _cacheStore.Upsert(new ScanCacheEntry
             {
                 CanonicalPath = probe.CanonicalPath,
-                RealPath = probe.CanonicalPath,
+                RealPath = probe.OriginalPath,
                 FileIdentity = probe.Identity,
                 Sha256 = hash,
                 ScannerFingerprint = _scannerFingerprint,
@@ -443,7 +454,7 @@ namespace MLVScan.Services
 
         private static StringComparer GetPathComparer()
         {
-            return RuntimeInformationHelper.IsWindows
+            return RuntimeInformationHelper.IsWindows || RuntimeInformationHelper.IsMacOs
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
         }

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -135,7 +135,7 @@ namespace MLVScan.Services
 
             var scannedResult = ThreatVerdictBuilder.Build(filePath, hash, actualFindings);
 
-            if (actualFindings.Count >= Config.SuspiciousThreshold || scannedResult.ThreatVerdict.ShouldBypassThreshold)
+            if (scannedResult.ThreatVerdict.Kind != ThreatVerdictKind.None)
             {
                 results[filePath] = scannedResult;
 
@@ -145,16 +145,16 @@ namespace MLVScan.Services
                     var familyName = scannedResult.ThreatVerdict.PrimaryFamily?.DisplayName;
                     if (!string.IsNullOrWhiteSpace(familyName))
                     {
-                        Logger.Warning($"Found {actualFindings.Count} suspicious pattern(s) in {fileName} - {scannedResult.ThreatVerdict.Title}: {familyName}");
+                        Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}: {familyName}");
                     }
                     else
                     {
-                        Logger.Warning($"Found {actualFindings.Count} suspicious pattern(s) in {fileName} - {scannedResult.ThreatVerdict.Title}");
+                        Logger.Warning($"Detected likely malware in {fileName} - {scannedResult.ThreatVerdict.Title}");
                     }
                 }
                 else
                 {
-                    Logger.Warning($"Found {actualFindings.Count} suspicious pattern(s) in {fileName}");
+                    Logger.Warning($"Detected suspicious behavior in {fileName} - {scannedResult.ThreatVerdict.Title}");
                 }
             }
         }

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -30,12 +30,13 @@ namespace MLVScan.Services
         private const long MaxAssemblyScanBytes = 256L * 1024 * 1024;
 
         private readonly IFileIdentityProvider _fileIdentityProvider;
-        private readonly IScanCacheStore _cacheStore;
         private readonly IResolverCatalogProvider _resolverCatalogProvider;
         private readonly LoaderScanTelemetryHub _telemetry;
         private readonly TargetAssemblyScopeFilter _scopeFilter = new TargetAssemblyScopeFilter();
         private readonly string _scannerFingerprint;
         private readonly string _selfAssemblyHash;
+        private IScanCacheStore _cacheStore;
+        private bool _cacheUnavailable;
 
         protected PluginScannerBase(
             IScanLogger logger,
@@ -53,7 +54,6 @@ namespace MLVScan.Services
 
             _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             _fileIdentityProvider = new CrossPlatformFileIdentityProvider();
-            _cacheStore = CreateDefaultCacheStore(environment);
             _resolverCatalogProvider = resolverProvider as IResolverCatalogProvider;
 
             var rules = RuleFactory.CreateDefaultRules().ToArray();
@@ -148,18 +148,23 @@ namespace MLVScan.Services
                 }
             }
 
-            if (Config.EnableScanCache)
+            var cacheStore = GetCacheStore();
+            if (cacheStore != null)
             {
-                _cacheStore.PruneMissingEntries(activeCanonicalPaths);
+                cacheStore.PruneMissingEntries(activeCanonicalPaths);
             }
 
             OnScanComplete(results);
             _telemetry.CompleteRun(effectiveRoots.Count, candidateFiles.Length, results.Count);
 
-            var artifactPath = _telemetry.TryWriteArtifact(Path.Combine(Environment.DataDirectory, "Diagnostics"));
-            if (!string.IsNullOrWhiteSpace(artifactPath))
+            var dataDirectory = TryGetDataDirectory();
+            if (!string.IsNullOrWhiteSpace(dataDirectory))
             {
-                Logger.Debug($"Wrote loader profile artifact: {artifactPath}");
+                var artifactPath = _telemetry.TryWriteArtifact(Path.Combine(dataDirectory, "Diagnostics"));
+                if (!string.IsNullOrWhiteSpace(artifactPath))
+                {
+                    Logger.Debug($"Wrote loader profile artifact: {artifactPath}");
+                }
             }
 
             return results;
@@ -276,14 +281,20 @@ namespace MLVScan.Services
             string resolverFingerprint,
             Dictionary<string, ScannedPluginResult> results)
         {
-            var entry = _cacheStore.TryGetByPath(probe.CanonicalPath);
+            var cacheStore = GetCacheStore();
+            if (cacheStore == null)
+            {
+                return false;
+            }
+
+            var entry = cacheStore.TryGetByPath(probe.CanonicalPath);
             if (entry == null)
             {
                 _telemetry.IncrementCounter("Cache.PathMiss");
                 return false;
             }
 
-            if (!entry.CanReuseStrictly(probe, _scannerFingerprint, resolverFingerprint, _cacheStore.CanTrustCleanEntries))
+            if (!entry.CanReuseStrictly(probe, _scannerFingerprint, resolverFingerprint, cacheStore.CanTrustCleanEntries))
             {
                 _telemetry.IncrementCounter("Cache.PathRejected");
                 return false;
@@ -301,7 +312,13 @@ namespace MLVScan.Services
             string resolverFingerprint,
             Dictionary<string, ScannedPluginResult> results)
         {
-            var entry = _cacheStore.TryGetByHash(hash);
+            var cacheStore = GetCacheStore();
+            if (cacheStore == null)
+            {
+                return false;
+            }
+
+            var entry = cacheStore.TryGetByHash(hash);
             if (entry == null)
             {
                 _telemetry.IncrementCounter("Cache.HashMiss");
@@ -316,7 +333,7 @@ namespace MLVScan.Services
             }
 
             if (entry.Result?.ThreatVerdict?.Kind == ThreatVerdictKind.None &&
-                !_cacheStore.CanTrustCleanEntries)
+                !cacheStore.CanTrustCleanEntries)
             {
                 _telemetry.IncrementCounter("Cache.HashRejected");
                 return false;
@@ -373,12 +390,13 @@ namespace MLVScan.Services
 
         private void UpsertCacheEntry(FileProbe probe, string hash, string resolverFingerprint, ScannedPluginResult result)
         {
-            if (!Config.EnableScanCache)
+            var cacheStore = GetCacheStore();
+            if (cacheStore == null)
             {
                 return;
             }
 
-            _cacheStore.Upsert(new ScanCacheEntry
+            cacheStore.Upsert(new ScanCacheEntry
             {
                 CanonicalPath = probe.CanonicalPath,
                 RealPath = probe.OriginalPath,
@@ -403,10 +421,48 @@ namespace MLVScan.Services
             return _resolverCatalogProvider.ContextFingerprint;
         }
 
+        private IScanCacheStore GetCacheStore()
+        {
+            if (!Config.EnableScanCache || _cacheUnavailable)
+            {
+                return null;
+            }
+
+            if (_cacheStore != null)
+            {
+                return _cacheStore;
+            }
+
+            try
+            {
+                _cacheStore = CreateDefaultCacheStore(Environment);
+            }
+            catch (Exception ex)
+            {
+                _cacheUnavailable = true;
+                Logger.Warning($"Scan cache unavailable; continuing without cache reuse: {ex.Message}");
+            }
+
+            return _cacheStore;
+        }
+
         private bool IsExactSelfCopy(string hash)
         {
             return !string.IsNullOrWhiteSpace(_selfAssemblyHash) &&
                    _selfAssemblyHash.Equals(hash, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private string TryGetDataDirectory()
+        {
+            try
+            {
+                return Environment.DataDirectory;
+            }
+            catch (Exception ex)
+            {
+                Logger.Warning($"Diagnostics output unavailable: {ex.Message}");
+                return null;
+            }
         }
 
         private static string GetSelfAssemblyHash(string selfAssemblyPath)

--- a/Services/PluginScannerBase.cs
+++ b/Services/PluginScannerBase.cs
@@ -42,7 +42,8 @@ namespace MLVScan.Services
             IAssemblyResolverProvider resolverProvider,
             MLVScanConfig config,
             IConfigManager configManager,
-            IPlatformEnvironment environment)
+            IPlatformEnvironment environment,
+            LoaderScanTelemetryHub telemetry)
         {
             Logger = logger ?? throw new ArgumentNullException(nameof(logger));
             ResolverProvider = resolverProvider ?? throw new ArgumentNullException(nameof(resolverProvider));
@@ -50,7 +51,7 @@ namespace MLVScan.Services
             ConfigManager = configManager ?? throw new ArgumentNullException(nameof(configManager));
             Environment = environment ?? throw new ArgumentNullException(nameof(environment));
 
-            _telemetry = new LoaderScanTelemetryHub();
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             _fileIdentityProvider = new CrossPlatformFileIdentityProvider();
             _cacheStore = CreateDefaultCacheStore(environment);
             _resolverCatalogProvider = resolverProvider as IResolverCatalogProvider;
@@ -71,6 +72,15 @@ namespace MLVScan.Services
         /// Checks if a file path is this scanner's own assembly.
         /// </summary>
         protected abstract bool IsSelfAssembly(string filePath);
+
+        /// <summary>
+        /// Gets directories that should participate in dependency resolution, even if they are
+        /// currently excluded from target scanning.
+        /// </summary>
+        protected virtual IEnumerable<string> GetResolverDirectories()
+        {
+            return GetScanDirectories();
+        }
 
         /// <summary>
         /// Performs any platform-specific post-scan processing.
@@ -103,8 +113,15 @@ namespace MLVScan.Services
             var effectiveRoots = _scopeFilter.BuildEffectiveRoots(rawRoots, Config);
             _telemetry.AddPhaseElapsed("Scope.BuildEffectiveRoots", scopeStart);
 
-            var resolverFingerprint = BuildResolverCatalog(effectiveRoots);
             var pathComparer = GetPathComparer();
+            var resolverRoots = GetResolverDirectories()
+                .Concat(Config.AdditionalTargetRoots)
+                .Where(static root => !string.IsNullOrWhiteSpace(root))
+                .Select(Path.GetFullPath)
+                .Distinct(pathComparer)
+                .ToArray();
+
+            var resolverFingerprint = BuildResolverCatalog(resolverRoots);
             var candidateFiles = effectiveRoots
                 .SelectMany(EnumerateCandidateFiles)
                 .Distinct(pathComparer)

--- a/Services/PromptGeneratorService.cs
+++ b/Services/PromptGeneratorService.cs
@@ -40,7 +40,7 @@ namespace MLVScan.Services
             sb.AppendLine("## Mod Information");
             sb.AppendLine($"- **Filename**: {modName}");
             sb.AppendLine($"- **Scan Date**: {DateTime.Now}");
-            sb.AppendLine($"- **Total Suspicious Patterns**: {findings.Count}");
+            sb.AppendLine($"- **Total Findings**: {findings.Count}");
             sb.AppendLine();
 
             // Severity breakdown

--- a/Services/Resolution/AssemblyResolverCatalogBuilder.cs
+++ b/Services/Resolution/AssemblyResolverCatalogBuilder.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace MLVScan.Services.Resolution
@@ -41,8 +42,9 @@ namespace MLVScan.Services.Resolution
                         candidates.Add(candidate);
 
                         var fileInfo = new FileInfo(fullPath);
+                        var contentFingerprint = ComputeContentFingerprint(fullPath);
                         fingerprintLines.Add(
-                            $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{comparisonKey}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
+                            $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{comparisonKey}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}|{contentFingerprint}");
                     }
                     catch (UnauthorizedAccessException)
                     {
@@ -104,6 +106,14 @@ namespace MLVScan.Services.Resolution
         {
             var payload = string.Join("\n", lines.OrderBy(static line => line, StringComparer.Ordinal));
             return Services.HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(payload));
+        }
+
+        private static string ComputeContentFingerprint(string path)
+        {
+            using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(stream);
+            return BitConverter.ToString(hash).Replace("-", string.Empty).ToLowerInvariant();
         }
 
         private static string FormatPublicKeyToken(byte[] token)

--- a/Services/Resolution/AssemblyResolverCatalogBuilder.cs
+++ b/Services/Resolution/AssemblyResolverCatalogBuilder.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace MLVScan.Services.Resolution
+{
+    internal static class AssemblyResolverCatalogBuilder
+    {
+        public static ResolverCatalog Build(IEnumerable<ResolverRoot> roots)
+        {
+            var candidates = new List<ResolverCatalogCandidate>();
+            var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var fingerprintLines = new List<string>();
+
+            foreach (var root in roots
+                         .Where(static root => !string.IsNullOrWhiteSpace(root.Path) && Directory.Exists(root.Path))
+                         .OrderBy(static root => root.Priority)
+                         .ThenBy(static root => root.Path, StringComparer.OrdinalIgnoreCase))
+            {
+                foreach (var path in Directory.EnumerateFiles(root.Path, "*", SearchOption.AllDirectories)
+                             .Where(IsAssemblyLike))
+                {
+                    var fullPath = Path.GetFullPath(path);
+                    if (!seenPaths.Add(fullPath))
+                    {
+                        continue;
+                    }
+
+                    if (!TryReadAssemblyIdentity(fullPath, out var candidate))
+                    {
+                        continue;
+                    }
+
+                    candidate.Priority = root.Priority;
+                    candidates.Add(candidate);
+
+                    var fileInfo = new FileInfo(fullPath);
+                    fingerprintLines.Add(
+                        $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{fullPath}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
+                }
+            }
+
+            var grouped = candidates
+                .GroupBy(candidate => candidate.SimpleName, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (IReadOnlyList<ResolverCatalogCandidate>)group
+                        .OrderBy(candidate => candidate.Priority)
+                        .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase)
+                        .ToArray(),
+                    StringComparer.OrdinalIgnoreCase);
+
+            return new ResolverCatalog
+            {
+                Fingerprint = ComputeFingerprint(fingerprintLines),
+                CandidatesBySimpleName = grouped
+            };
+        }
+
+        private static bool TryReadAssemblyIdentity(string path, out ResolverCatalogCandidate candidate)
+        {
+            candidate = null;
+
+            try
+            {
+                var assemblyName = AssemblyName.GetAssemblyName(path);
+                candidate = new ResolverCatalogCandidate
+                {
+                    SimpleName = assemblyName.Name ?? string.Empty,
+                    FullName = assemblyName.FullName ?? string.Empty,
+                    Version = assemblyName.Version?.ToString() ?? string.Empty,
+                    PublicKeyToken = FormatPublicKeyToken(assemblyName.GetPublicKeyToken()),
+                    Path = path
+                };
+
+                return !string.IsNullOrWhiteSpace(candidate.SimpleName);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static string ComputeFingerprint(IEnumerable<string> lines)
+        {
+            var payload = string.Join("\n", lines.OrderBy(static line => line, StringComparer.Ordinal));
+            return Services.HashUtility.CalculateBytesHash(Encoding.UTF8.GetBytes(payload));
+        }
+
+        private static string FormatPublicKeyToken(byte[] token)
+        {
+            if (token == null || token.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return BitConverter.ToString(token).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static bool IsAssemblyLike(string path)
+        {
+            var extension = Path.GetExtension(path);
+            return extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                   || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)
+                   || extension.Equals(".winmd", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/Services/Resolution/AssemblyResolverCatalogBuilder.cs
+++ b/Services/Resolution/AssemblyResolverCatalogBuilder.cs
@@ -26,7 +26,8 @@ namespace MLVScan.Services.Resolution
                     try
                     {
                         var fullPath = Path.GetFullPath(path);
-                        if (!seenPaths.Add(GetComparisonKey(fullPath)))
+                        var comparisonKey = GetComparisonKey(fullPath);
+                        if (!seenPaths.Add(comparisonKey))
                         {
                             continue;
                         }
@@ -41,7 +42,7 @@ namespace MLVScan.Services.Resolution
 
                         var fileInfo = new FileInfo(fullPath);
                         fingerprintLines.Add(
-                            $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{fullPath}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
+                            $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{comparisonKey}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
                     }
                     catch (UnauthorizedAccessException)
                     {

--- a/Services/Resolution/AssemblyResolverCatalogBuilder.cs
+++ b/Services/Resolution/AssemblyResolverCatalogBuilder.cs
@@ -12,36 +12,53 @@ namespace MLVScan.Services.Resolution
     {
         public static ResolverCatalog Build(IEnumerable<ResolverRoot> roots)
         {
-            var pathComparer = GetPathComparer();
             var candidates = new List<ResolverCatalogCandidate>();
-            var seenPaths = new HashSet<string>(pathComparer);
+            var seenPaths = new HashSet<string>(StringComparer.Ordinal);
             var fingerprintLines = new List<string>();
 
             foreach (var root in roots
                          .Where(static root => !string.IsNullOrWhiteSpace(root.Path) && Directory.Exists(root.Path))
                          .OrderBy(static root => root.Priority)
-                         .ThenBy(static root => root.Path, pathComparer))
+                         .ThenBy(root => GetComparisonKey(root.Path), StringComparer.Ordinal))
             {
-                foreach (var path in Directory.EnumerateFiles(root.Path, "*", SearchOption.AllDirectories)
-                             .Where(IsAssemblyLike))
+                foreach (var path in EnumerateAssemblyPaths(root.Path))
                 {
-                    var fullPath = Path.GetFullPath(path);
-                    if (!seenPaths.Add(fullPath))
+                    try
+                    {
+                        var fullPath = Path.GetFullPath(path);
+                        if (!seenPaths.Add(GetComparisonKey(fullPath)))
+                        {
+                            continue;
+                        }
+
+                        if (!TryReadAssemblyIdentity(fullPath, out var candidate))
+                        {
+                            continue;
+                        }
+
+                        candidate.Priority = root.Priority;
+                        candidates.Add(candidate);
+
+                        var fileInfo = new FileInfo(fullPath);
+                        fingerprintLines.Add(
+                            $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{fullPath}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
+                    }
+                    catch (UnauthorizedAccessException)
                     {
                         continue;
                     }
-
-                    if (!TryReadAssemblyIdentity(fullPath, out var candidate))
+                    catch (FileNotFoundException)
                     {
                         continue;
                     }
-
-                    candidate.Priority = root.Priority;
-                    candidates.Add(candidate);
-
-                    var fileInfo = new FileInfo(fullPath);
-                    fingerprintLines.Add(
-                        $"{candidate.SimpleName}|{candidate.Version}|{candidate.PublicKeyToken}|{root.Priority}|{fullPath}|{fileInfo.Length}|{fileInfo.LastWriteTimeUtc.Ticks}");
+                    catch (DirectoryNotFoundException)
+                    {
+                        continue;
+                    }
+                    catch (IOException)
+                    {
+                        continue;
+                    }
                 }
             }
 
@@ -51,7 +68,7 @@ namespace MLVScan.Services.Resolution
                     group => group.Key,
                     group => (IReadOnlyList<ResolverCatalogCandidate>)group
                         .OrderBy(candidate => candidate.Priority)
-                        .ThenBy(candidate => candidate.Path, pathComparer)
+                        .ThenBy(candidate => GetComparisonKey(candidate.Path), StringComparer.Ordinal)
                         .ToArray(),
                     StringComparer.OrdinalIgnoreCase);
 
@@ -106,11 +123,134 @@ namespace MLVScan.Services.Resolution
                    || extension.Equals(".winmd", StringComparison.OrdinalIgnoreCase);
         }
 
-        private static StringComparer GetPathComparer()
+        private static IEnumerable<string> EnumerateAssemblyPaths(string rootPath)
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+            IEnumerator<string> enumerator;
+            try
+            {
+                enumerator = Directory.EnumerateFiles(rootPath, "*", SearchOption.AllDirectories).GetEnumerator();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                yield break;
+            }
+            catch (FileNotFoundException)
+            {
+                yield break;
+            }
+            catch (DirectoryNotFoundException)
+            {
+                yield break;
+            }
+            catch (IOException)
+            {
+                yield break;
+            }
+
+            using (enumerator)
+            {
+                while (true)
+                {
+                    string current;
+                    try
+                    {
+                        if (!enumerator.MoveNext())
+                        {
+                            yield break;
+                        }
+
+                        current = enumerator.Current;
+                    }
+                    catch (UnauthorizedAccessException)
+                    {
+                        continue;
+                    }
+                    catch (FileNotFoundException)
+                    {
+                        continue;
+                    }
+                    catch (DirectoryNotFoundException)
+                    {
+                        continue;
+                    }
+                    catch (IOException)
+                    {
+                        continue;
+                    }
+
+                    if (IsAssemblyLike(current))
+                    {
+                        yield return current;
+                    }
+                }
+            }
+        }
+
+        private static string GetComparisonKey(string path)
+        {
+            var fullPath = Path.GetFullPath(path);
+            return GetPathComparerForRoot(fullPath) == StringComparer.OrdinalIgnoreCase
+                ? fullPath.ToUpperInvariant()
+                : fullPath;
+        }
+
+        private static StringComparer GetPathComparerForRoot(string pathRoot)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return StringComparer.OrdinalIgnoreCase;
+            }
+
+            var probePath = FindExistingPathForSensitivityProbe(pathRoot);
+            if (string.IsNullOrWhiteSpace(probePath))
+            {
+                return StringComparer.Ordinal;
+            }
+
+            var alternateCasePath = GetAlternateCasePath(probePath);
+            if (string.Equals(alternateCasePath, probePath, StringComparison.Ordinal))
+            {
+                return StringComparer.Ordinal;
+            }
+
+            return File.Exists(alternateCasePath) || Directory.Exists(alternateCasePath)
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal;
+        }
+
+        private static string FindExistingPathForSensitivityProbe(string path)
+        {
+            var current = Path.GetFullPath(path);
+            while (!string.IsNullOrWhiteSpace(current))
+            {
+                if (File.Exists(current) || Directory.Exists(current))
+                {
+                    return current;
+                }
+
+                current = Path.GetDirectoryName(current);
+            }
+
+            return string.Empty;
+        }
+
+        private static string GetAlternateCasePath(string path)
+        {
+            var chars = path.ToCharArray();
+            for (var i = 0; i < chars.Length; i++)
+            {
+                if (!char.IsLetter(chars[i]))
+                {
+                    continue;
+                }
+
+                chars[i] = char.IsUpper(chars[i])
+                    ? char.ToLowerInvariant(chars[i])
+                    : char.ToUpperInvariant(chars[i]);
+                break;
+            }
+
+            return new string(chars);
         }
     }
 }

--- a/Services/Resolution/AssemblyResolverCatalogBuilder.cs
+++ b/Services/Resolution/AssemblyResolverCatalogBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text;
 
 namespace MLVScan.Services.Resolution
@@ -11,14 +12,15 @@ namespace MLVScan.Services.Resolution
     {
         public static ResolverCatalog Build(IEnumerable<ResolverRoot> roots)
         {
+            var pathComparer = GetPathComparer();
             var candidates = new List<ResolverCatalogCandidate>();
-            var seenPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var seenPaths = new HashSet<string>(pathComparer);
             var fingerprintLines = new List<string>();
 
             foreach (var root in roots
                          .Where(static root => !string.IsNullOrWhiteSpace(root.Path) && Directory.Exists(root.Path))
                          .OrderBy(static root => root.Priority)
-                         .ThenBy(static root => root.Path, StringComparer.OrdinalIgnoreCase))
+                         .ThenBy(static root => root.Path, pathComparer))
             {
                 foreach (var path in Directory.EnumerateFiles(root.Path, "*", SearchOption.AllDirectories)
                              .Where(IsAssemblyLike))
@@ -49,15 +51,11 @@ namespace MLVScan.Services.Resolution
                     group => group.Key,
                     group => (IReadOnlyList<ResolverCatalogCandidate>)group
                         .OrderBy(candidate => candidate.Priority)
-                        .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase)
+                        .ThenBy(candidate => candidate.Path, pathComparer)
                         .ToArray(),
                     StringComparer.OrdinalIgnoreCase);
 
-            return new ResolverCatalog
-            {
-                Fingerprint = ComputeFingerprint(fingerprintLines),
-                CandidatesBySimpleName = grouped
-            };
+            return ResolverCatalog.Create(ComputeFingerprint(fingerprintLines), grouped);
         }
 
         private static bool TryReadAssemblyIdentity(string path, out ResolverCatalogCandidate candidate)
@@ -106,6 +104,13 @@ namespace MLVScan.Services.Resolution
             return extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
                    || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase)
                    || extension.Equals(".winmd", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static StringComparer GetPathComparer()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
         }
     }
 }

--- a/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
+++ b/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
@@ -42,9 +42,12 @@ namespace MLVScan.Services.Resolution
         {
             lock (_sync)
             {
-                _resolver ??= new IndexedAssemblyResolver(
-                    AssemblyResolverCatalogBuilder.Build(GetStableRoots()),
-                    _telemetry);
+                if (_resolver == null)
+                {
+                    var catalog = AssemblyResolverCatalogBuilder.Build(GetStableRoots());
+                    ContextFingerprint = catalog.Fingerprint;
+                    _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
+                }
 
                 return _resolver;
             }

--- a/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
+++ b/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
@@ -32,9 +32,8 @@ namespace MLVScan.Services.Resolution
             var catalog = AssemblyResolverCatalogBuilder.Build(roots);
             lock (_sync)
             {
-                _resolver?.Dispose();
-                _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
                 ContextFingerprint = catalog.Fingerprint;
+                _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
             }
         }
 

--- a/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
+++ b/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
@@ -11,11 +11,11 @@ namespace MLVScan.Services.Resolution
     {
         private readonly object _sync = new object();
         private readonly LoaderScanTelemetryHub _telemetry;
-        private IndexedAssemblyResolver _resolver;
+        private ResolverCatalog _catalog;
 
-        protected CatalogingAssemblyResolverProviderBase()
+        protected CatalogingAssemblyResolverProviderBase(LoaderScanTelemetryHub telemetry)
         {
-            _telemetry = new LoaderScanTelemetryHub();
+            _telemetry = telemetry ?? throw new ArgumentNullException(nameof(telemetry));
             ContextFingerprint = ResolverCatalog.Empty.Fingerprint;
         }
 
@@ -32,24 +32,29 @@ namespace MLVScan.Services.Resolution
             var catalog = AssemblyResolverCatalogBuilder.Build(roots);
             lock (_sync)
             {
+                _catalog = catalog;
                 ContextFingerprint = catalog.Fingerprint;
-                _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
             }
         }
 
         public IAssemblyResolver CreateResolver()
         {
+            ResolverCatalog catalog;
             lock (_sync)
             {
-                if (_resolver == null)
+                if (_catalog == null)
                 {
-                    var catalog = AssemblyResolverCatalogBuilder.Build(GetStableRoots());
-                    ContextFingerprint = catalog.Fingerprint;
-                    _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
+                    _catalog = AssemblyResolverCatalogBuilder.Build(GetStableRoots());
+                    ContextFingerprint = _catalog.Fingerprint;
                 }
 
-                return _resolver;
+                catalog = _catalog;
             }
+
+            // Return a fresh resolver for each scan/read context so Cecil resolution state
+            // cannot bleed between different plugins that bundle private assemblies with
+            // the same identity.
+            return new IndexedAssemblyResolver(catalog, _telemetry);
         }
 
         protected abstract IEnumerable<ResolverRoot> GetStableRoots();

--- a/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
+++ b/Services/Resolution/CatalogingAssemblyResolverProviderBase.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MLVScan.Abstractions;
+using MLVScan.Services.Diagnostics;
+using Mono.Cecil;
+
+namespace MLVScan.Services.Resolution
+{
+    public abstract class CatalogingAssemblyResolverProviderBase : IAssemblyResolverProvider, IResolverCatalogProvider
+    {
+        private readonly object _sync = new object();
+        private readonly LoaderScanTelemetryHub _telemetry;
+        private IndexedAssemblyResolver _resolver;
+
+        protected CatalogingAssemblyResolverProviderBase()
+        {
+            _telemetry = new LoaderScanTelemetryHub();
+            ContextFingerprint = ResolverCatalog.Empty.Fingerprint;
+        }
+
+        public string ContextFingerprint { get; private set; }
+
+        public void BuildCatalog(IEnumerable<string> targetRoots)
+        {
+            var roots = GetStableRoots()
+                .Concat((targetRoots ?? Array.Empty<string>())
+                    .Where(static root => !string.IsNullOrWhiteSpace(root))
+                    .Select(static root => new ResolverRoot(root, 20)))
+                .ToArray();
+
+            var catalog = AssemblyResolverCatalogBuilder.Build(roots);
+            lock (_sync)
+            {
+                _resolver?.Dispose();
+                _resolver = new IndexedAssemblyResolver(catalog, _telemetry);
+                ContextFingerprint = catalog.Fingerprint;
+            }
+        }
+
+        public IAssemblyResolver CreateResolver()
+        {
+            lock (_sync)
+            {
+                _resolver ??= new IndexedAssemblyResolver(
+                    AssemblyResolverCatalogBuilder.Build(GetStableRoots()),
+                    _telemetry);
+
+                return _resolver;
+            }
+        }
+
+        protected abstract IEnumerable<ResolverRoot> GetStableRoots();
+    }
+}

--- a/Services/Resolution/IResolverCatalogProvider.cs
+++ b/Services/Resolution/IResolverCatalogProvider.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace MLVScan.Services.Resolution
+{
+    internal interface IResolverCatalogProvider
+    {
+        string ContextFingerprint { get; }
+
+        void BuildCatalog(IEnumerable<string> targetRoots);
+    }
+}

--- a/Services/Resolution/IndexedAssemblyResolver.cs
+++ b/Services/Resolution/IndexedAssemblyResolver.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Mono.Cecil;
 using MLVScan.Services.Diagnostics;
 
 namespace MLVScan.Services.Resolution
 {
-    internal sealed class IndexedAssemblyResolver : BaseAssemblyResolver, IDisposable
+    internal sealed class IndexedAssemblyResolver : BaseAssemblyResolver
     {
         private readonly ResolverCatalog _catalog;
         private readonly Dictionary<string, AssemblyDefinition> _resolved = new Dictionary<string, AssemblyDefinition>(StringComparer.Ordinal);
@@ -76,15 +77,20 @@ namespace MLVScan.Services.Resolution
             throw new AssemblyResolutionException(name);
         }
 
-        public new void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            foreach (var assembly in _resolved.Values.Distinct())
+            if (disposing)
             {
-                assembly.Dispose();
+                foreach (var assembly in _resolved.Values.Distinct())
+                {
+                    assembly.Dispose();
+                }
+
+                _resolved.Clear();
+                _missing.Clear();
             }
 
-            _resolved.Clear();
-            _missing.Clear();
+            base.Dispose(disposing);
         }
 
         private static IEnumerable<ResolverCatalogCandidate> OrderCandidates(
@@ -97,7 +103,7 @@ namespace MLVScan.Services.Resolution
             return candidates
                 .OrderBy(candidate => CandidateMatches(reference.Name, expectedVersion, expectedToken, candidate) ? 0 : 1)
                 .ThenBy(candidate => candidate.Priority)
-                .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase);
+                .ThenBy(candidate => candidate.Path, GetPathComparer());
         }
 
         private static bool CandidateMatches(
@@ -134,6 +140,13 @@ namespace MLVScan.Services.Resolution
             }
 
             return BitConverter.ToString(token).Replace("-", string.Empty).ToLowerInvariant();
+        }
+
+        private static StringComparer GetPathComparer()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal;
         }
     }
 }

--- a/Services/Resolution/IndexedAssemblyResolver.cs
+++ b/Services/Resolution/IndexedAssemblyResolver.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using MLVScan.Services.Diagnostics;
+
+namespace MLVScan.Services.Resolution
+{
+    internal sealed class IndexedAssemblyResolver : BaseAssemblyResolver, IDisposable
+    {
+        private readonly ResolverCatalog _catalog;
+        private readonly Dictionary<string, AssemblyDefinition> _resolved = new Dictionary<string, AssemblyDefinition>(StringComparer.Ordinal);
+        private readonly HashSet<string> _missing = new HashSet<string>(StringComparer.Ordinal);
+        private readonly LoaderScanTelemetryHub _telemetry;
+
+        public IndexedAssemblyResolver(ResolverCatalog catalog, LoaderScanTelemetryHub telemetry = null)
+        {
+            _catalog = catalog ?? ResolverCatalog.Empty;
+            _telemetry = telemetry;
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            return Resolve(name, new ReaderParameters
+            {
+                AssemblyResolver = this
+            });
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var cacheKey = name.FullName;
+            if (_resolved.TryGetValue(cacheKey, out var cached))
+            {
+                _telemetry?.IncrementCounter("Resolver.CacheHit");
+                return cached;
+            }
+
+            if (_missing.Contains(cacheKey))
+            {
+                _telemetry?.IncrementCounter("Resolver.NegativeCacheHit");
+                throw new AssemblyResolutionException(name);
+            }
+
+            if (!_catalog.CandidatesBySimpleName.TryGetValue(name.Name, out var candidates))
+            {
+                _missing.Add(cacheKey);
+                _telemetry?.IncrementCounter("Resolver.Miss");
+                throw new AssemblyResolutionException(name);
+            }
+
+            foreach (var candidate in OrderCandidates(name, candidates))
+            {
+                try
+                {
+                    var readParameters = parameters ?? new ReaderParameters();
+                    readParameters.AssemblyResolver = this;
+                    var assembly = AssemblyDefinition.ReadAssembly(candidate.Path, readParameters);
+                    _resolved[cacheKey] = assembly;
+                    _telemetry?.IncrementCounter("Resolver.ResolveHit");
+                    return assembly;
+                }
+                catch
+                {
+                    // Try the next candidate path.
+                }
+            }
+
+            _missing.Add(cacheKey);
+            _telemetry?.IncrementCounter("Resolver.Miss");
+            throw new AssemblyResolutionException(name);
+        }
+
+        public new void Dispose()
+        {
+            foreach (var assembly in _resolved.Values.Distinct())
+            {
+                assembly.Dispose();
+            }
+
+            _resolved.Clear();
+            _missing.Clear();
+        }
+
+        private static IEnumerable<ResolverCatalogCandidate> OrderCandidates(
+            AssemblyNameReference reference,
+            IEnumerable<ResolverCatalogCandidate> candidates)
+        {
+            var expectedVersion = reference.Version?.ToString() ?? string.Empty;
+            var expectedToken = FormatPublicKeyToken(reference.PublicKeyToken);
+
+            return candidates
+                .OrderBy(candidate => CandidateMatches(reference.Name, expectedVersion, expectedToken, candidate) ? 0 : 1)
+                .ThenBy(candidate => candidate.Priority)
+                .ThenBy(candidate => candidate.Path, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static bool CandidateMatches(
+            string simpleName,
+            string expectedVersion,
+            string expectedToken,
+            ResolverCatalogCandidate candidate)
+        {
+            if (!string.Equals(simpleName, candidate.SimpleName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(expectedVersion) &&
+                !string.Equals(expectedVersion, candidate.Version, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrWhiteSpace(expectedToken) &&
+                !string.Equals(expectedToken, candidate.PublicKeyToken, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string FormatPublicKeyToken(byte[] token)
+        {
+            if (token == null || token.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return BitConverter.ToString(token).Replace("-", string.Empty).ToLowerInvariant();
+        }
+    }
+}

--- a/Services/Resolution/ResolverCatalogModels.cs
+++ b/Services/Resolution/ResolverCatalogModels.cs
@@ -1,21 +1,40 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.ObjectModel;
 
 namespace MLVScan.Services.Resolution
 {
     internal sealed class ResolverCatalog
     {
-        public static readonly ResolverCatalog Empty = new ResolverCatalog
+        private static readonly IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> EmptyCandidates =
+            new ReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(
+                new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(StringComparer.OrdinalIgnoreCase));
+
+        private ResolverCatalog(
+            string fingerprint,
+            IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> candidatesBySimpleName)
         {
-            Fingerprint = "empty",
-            CandidatesBySimpleName = new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(StringComparer.OrdinalIgnoreCase)
-        };
+            Fingerprint = string.IsNullOrWhiteSpace(fingerprint) ? "empty" : fingerprint;
+            CandidatesBySimpleName = candidatesBySimpleName ?? EmptyCandidates;
+        }
 
-        public string Fingerprint { get; set; } = "empty";
+        public static ResolverCatalog Empty { get; } = new ResolverCatalog("empty", EmptyCandidates);
 
-        public IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> CandidatesBySimpleName { get; set; } =
-            new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(StringComparer.OrdinalIgnoreCase);
+        public string Fingerprint { get; }
+
+        public IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> CandidatesBySimpleName { get; }
+
+        public static ResolverCatalog Create(
+            string fingerprint,
+            IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> candidatesBySimpleName)
+        {
+            return new ResolverCatalog(
+                fingerprint,
+                candidatesBySimpleName == null
+                    ? EmptyCandidates
+                    : new ReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(
+                        new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(candidatesBySimpleName, StringComparer.OrdinalIgnoreCase)));
+        }
     }
 
     internal sealed class ResolverCatalogCandidate

--- a/Services/Resolution/ResolverCatalogModels.cs
+++ b/Services/Resolution/ResolverCatalogModels.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MLVScan.Services.Resolution
+{
+    internal sealed class ResolverCatalog
+    {
+        public static readonly ResolverCatalog Empty = new ResolverCatalog
+        {
+            Fingerprint = "empty",
+            CandidatesBySimpleName = new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(StringComparer.OrdinalIgnoreCase)
+        };
+
+        public string Fingerprint { get; set; } = "empty";
+
+        public IReadOnlyDictionary<string, IReadOnlyList<ResolverCatalogCandidate>> CandidatesBySimpleName { get; set; } =
+            new Dictionary<string, IReadOnlyList<ResolverCatalogCandidate>>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal sealed class ResolverCatalogCandidate
+    {
+        public string SimpleName { get; set; } = string.Empty;
+
+        public string FullName { get; set; } = string.Empty;
+
+        public string Version { get; set; } = string.Empty;
+
+        public string PublicKeyToken { get; set; } = string.Empty;
+
+        public string Path { get; set; } = string.Empty;
+
+        public int Priority { get; set; }
+    }
+
+    public readonly struct ResolverRoot
+    {
+        public ResolverRoot(string path, int priority)
+        {
+            Path = path;
+            Priority = priority;
+        }
+
+        public string Path { get; }
+
+        public int Priority { get; }
+    }
+}

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -8,17 +8,17 @@ namespace MLVScan.Services.Scope;
 /// </summary>
 public sealed class TargetAssemblyScopeFilter
 {
-    private static readonly string[] ResolverOnlySegments =
+    private static readonly string[][] ResolverOnlySegmentSequences =
     [
-        "_Data\\Managed",
-        "MelonLoader\\Managed",
-        "MelonLoader\\net35",
-        "MelonLoader\\net6",
-        "BepInEx\\core",
-        "BepInEx\\cache",
-        "BepInEx\\interop",
-        ".nuget\\packages",
-        "dotnet\\shared"
+        ["*_Data", "Managed"],
+        ["MelonLoader", "Managed"],
+        ["MelonLoader", "net35"],
+        ["MelonLoader", "net6"],
+        ["BepInEx", "core"],
+        ["BepInEx", "cache"],
+        ["BepInEx", "interop"],
+        [".nuget", "packages"],
+        ["dotnet", "shared"]
     ];
 
     public IReadOnlyList<string> BuildEffectiveRoots(IEnumerable<string> candidateRoots, MLVScanConfig config)
@@ -77,8 +77,52 @@ public sealed class TargetAssemblyScopeFilter
 
     private static bool IsResolverOnlyPath(string path)
     {
-        return ResolverOnlySegments.Any(segment =>
-            path.IndexOf(segment, StringComparison.OrdinalIgnoreCase) >= 0);
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var pathSegments = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+        return ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(pathSegments, sequence));
+    }
+
+    private static bool ContainsSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
+    {
+        if (pathSegments.Count < candidateSegments.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i <= pathSegments.Count - candidateSegments.Count; i++)
+        {
+            var matched = true;
+
+            for (var j = 0; j < candidateSegments.Count; j++)
+            {
+                if (!SegmentMatches(pathSegments[i + j], candidateSegments[j]))
+                {
+                    matched = false;
+                    break;
+                }
+            }
+
+            if (matched)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool SegmentMatches(string actualSegment, string candidateSegment)
+    {
+        if (candidateSegment.StartsWith("*", StringComparison.Ordinal))
+        {
+            return actualSegment.EndsWith(candidateSegment.Substring(1), StringComparison.OrdinalIgnoreCase);
+        }
+
+        return string.Equals(actualSegment, candidateSegment, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool IsUnderAny(string fullPath, IEnumerable<string> roots)

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -38,7 +38,7 @@ public sealed class TargetAssemblyScopeFilter
                 continue;
             }
 
-            if (IsResolverOnlyPath(normalized) || IsUnderAny(normalized, config.ExcludedTargetRoots))
+            if (IsResolverOnlyRoot(normalized) || IsUnderAny(normalized, config.ExcludedTargetRoots))
             {
                 continue;
             }
@@ -67,7 +67,7 @@ public sealed class TargetAssemblyScopeFilter
             return false;
         }
 
-        if (IsResolverOnlyPath(fullPath) || IsUnderAny(fullPath, config.ExcludedTargetRoots))
+        if (IsResolverOnlyPath(fullPath, effectiveRoots) || IsUnderAny(fullPath, config.ExcludedTargetRoots))
         {
             return false;
         }
@@ -75,7 +75,7 @@ public sealed class TargetAssemblyScopeFilter
         return effectiveRoots.Any(root => IsUnderRoot(fullPath, root));
     }
 
-    private static bool IsResolverOnlyPath(string path)
+    private static bool IsResolverOnlyRoot(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -83,7 +83,33 @@ public sealed class TargetAssemblyScopeFilter
         }
 
         var pathSegments = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-        return ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(pathSegments, sequence));
+        return ResolverOnlySegmentSequences.Any(sequence => EndsWithSegmentSequence(pathSegments, sequence));
+    }
+
+    private static bool IsResolverOnlyPath(string path, IEnumerable<string> effectiveRoots)
+    {
+        foreach (var root in effectiveRoots)
+        {
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                continue;
+            }
+
+            var normalizedRoot = Normalize(root);
+            if (!IsUnderRoot(path, normalizedRoot))
+            {
+                continue;
+            }
+
+            var relativePath = Path.GetRelativePath(normalizedRoot, path);
+            var relativeSegments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+            if (ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(relativeSegments, sequence)))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
@@ -113,6 +139,25 @@ public sealed class TargetAssemblyScopeFilter
         }
 
         return false;
+    }
+
+    private static bool EndsWithSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
+    {
+        if (pathSegments.Count < candidateSegments.Count)
+        {
+            return false;
+        }
+
+        var startIndex = pathSegments.Count - candidateSegments.Count;
+        for (var i = 0; i < candidateSegments.Count; i++)
+        {
+            if (!SegmentMatches(pathSegments[startIndex + i], candidateSegments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool SegmentMatches(string actualSegment, string candidateSegment)

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -101,6 +101,12 @@ public sealed class TargetAssemblyScopeFilter
                 continue;
             }
 
+            var rootSegments = normalizedRoot.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+            if (ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(rootSegments, sequence)))
+            {
+                return true;
+            }
+
             var relativePath = Path.GetRelativePath(normalizedRoot, path);
             var relativeSegments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
             if (ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(relativeSegments, sequence)))

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -1,4 +1,5 @@
 using MLVScan.Models;
+using MLVScan.Services.Caching;
 
 namespace MLVScan.Services.Scope;
 
@@ -23,7 +24,7 @@ public sealed class TargetAssemblyScopeFilter
 
     public IReadOnlyList<string> BuildEffectiveRoots(IEnumerable<string> candidateRoots, MLVScanConfig config)
     {
-        var roots = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var roots = new HashSet<string>(GetPathComparer());
 
         foreach (var root in candidateRoots.Concat(config.AdditionalTargetRoots))
         {
@@ -38,7 +39,7 @@ public sealed class TargetAssemblyScopeFilter
                 continue;
             }
 
-            if (IsResolverOnlyRoot(normalized) || IsUnderAny(normalized, config.ExcludedTargetRoots))
+            if (IsResolverOnlyPath(normalized) || IsUnderAny(normalized, config.ExcludedTargetRoots))
             {
                 continue;
             }
@@ -46,7 +47,7 @@ public sealed class TargetAssemblyScopeFilter
             roots.Add(normalized);
         }
 
-        return roots.OrderBy(root => root, StringComparer.OrdinalIgnoreCase).ToList();
+        return roots.OrderBy(root => root, GetPathComparer()).ToList();
     }
 
     public bool IsTargetAssembly(string assemblyPath, IReadOnlyCollection<string> effectiveRoots, MLVScanConfig config)
@@ -67,7 +68,7 @@ public sealed class TargetAssemblyScopeFilter
             return false;
         }
 
-        if (IsUnderAny(fullPath, config.ExcludedTargetRoots))
+        if (IsResolverOnlyPath(fullPath) || IsUnderAny(fullPath, config.ExcludedTargetRoots))
         {
             return false;
         }
@@ -75,7 +76,7 @@ public sealed class TargetAssemblyScopeFilter
         return effectiveRoots.Any(root => IsUnderRoot(fullPath, root));
     }
 
-    private static bool IsResolverOnlyRoot(string path)
+    private static bool IsResolverOnlyPath(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -83,26 +84,35 @@ public sealed class TargetAssemblyScopeFilter
         }
 
         var pathSegments = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-        return ResolverOnlySegmentSequences.Any(sequence => EndsWithSegmentSequence(pathSegments, sequence));
+        return ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(pathSegments, sequence));
     }
 
-    private static bool EndsWithSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
+    private static bool ContainsSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
     {
         if (pathSegments.Count < candidateSegments.Count)
         {
             return false;
         }
 
-        var startIndex = pathSegments.Count - candidateSegments.Count;
-        for (var i = 0; i < candidateSegments.Count; i++)
+        for (var startIndex = 0; startIndex <= pathSegments.Count - candidateSegments.Count; startIndex++)
         {
-            if (!SegmentMatches(pathSegments[startIndex + i], candidateSegments[i]))
+            var matches = true;
+            for (var i = 0; i < candidateSegments.Count; i++)
             {
-                return false;
+                if (!SegmentMatches(pathSegments[startIndex + i], candidateSegments[i]))
+                {
+                    matches = false;
+                    break;
+                }
+            }
+
+            if (matches)
+            {
+                return true;
             }
         }
 
-        return true;
+        return false;
     }
 
     private static bool SegmentMatches(string actualSegment, string candidateSegment)
@@ -139,12 +149,27 @@ public sealed class TargetAssemblyScopeFilter
             ? root
             : root + Path.DirectorySeparatorChar;
 
-        return fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase)
-               || string.Equals(fullPath, root, StringComparison.OrdinalIgnoreCase);
+        var pathComparison = GetPathComparison();
+        return fullPath.StartsWith(normalizedRoot, pathComparison)
+               || string.Equals(fullPath, root, pathComparison);
     }
 
     private static string Normalize(string path)
     {
         return Path.GetFullPath(path);
+    }
+
+    private static StringComparer GetPathComparer()
+    {
+        return RuntimeInformationHelper.IsWindows || RuntimeInformationHelper.IsMacOs
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+    }
+
+    private static StringComparison GetPathComparison()
+    {
+        return RuntimeInformationHelper.IsWindows || RuntimeInformationHelper.IsMacOs
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
     }
 }

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -25,8 +25,11 @@ public sealed class TargetAssemblyScopeFilter
     public IReadOnlyList<string> BuildEffectiveRoots(IEnumerable<string> candidateRoots, MLVScanConfig config)
     {
         var roots = new HashSet<string>(GetPathComparer());
+        var candidateRootSet = candidateRoots ?? Array.Empty<string>();
+        var additionalTargetRoots = config?.AdditionalTargetRoots ?? Array.Empty<string>();
+        var excludedTargetRoots = config?.ExcludedTargetRoots ?? Array.Empty<string>();
 
-        foreach (var root in candidateRoots.Concat(config.AdditionalTargetRoots))
+        foreach (var root in candidateRootSet.Concat(additionalTargetRoots))
         {
             if (string.IsNullOrWhiteSpace(root))
             {
@@ -39,7 +42,7 @@ public sealed class TargetAssemblyScopeFilter
                 continue;
             }
 
-            if (IsResolverOnlyPath(normalized) || IsUnderAny(normalized, config.ExcludedTargetRoots))
+            if (IsResolverOnlyRoot(normalized) || IsUnderAny(normalized, excludedTargetRoots))
             {
                 continue;
             }
@@ -68,15 +71,16 @@ public sealed class TargetAssemblyScopeFilter
             return false;
         }
 
-        if (IsResolverOnlyPath(fullPath) || IsUnderAny(fullPath, config.ExcludedTargetRoots))
+        var excludedTargetRoots = config?.ExcludedTargetRoots ?? Array.Empty<string>();
+        if (IsUnderAny(fullPath, excludedTargetRoots))
         {
             return false;
         }
 
-        return effectiveRoots.Any(root => IsUnderRoot(fullPath, root));
+        return (effectiveRoots ?? Array.Empty<string>()).Any(root => IsTargetAssemblyUnderRoot(fullPath, root));
     }
 
-    private static bool IsResolverOnlyPath(string path)
+    private static bool IsResolverOnlyRoot(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {
@@ -84,35 +88,56 @@ public sealed class TargetAssemblyScopeFilter
         }
 
         var pathSegments = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-        return ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(pathSegments, sequence));
+        return ResolverOnlySegmentSequences.Any(sequence => EndsWithSegmentSequence(pathSegments, sequence));
     }
 
-    private static bool ContainsSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
+    private static bool IsTargetAssemblyUnderRoot(string fullPath, string root)
+    {
+        if (!IsUnderRoot(fullPath, root))
+        {
+            return false;
+        }
+
+        var relativePath = Path.GetRelativePath(root, fullPath);
+        var relativeSegments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
+        return !ResolverOnlySegmentSequences.Any(sequence => StartsWithSegmentSequence(relativeSegments, sequence));
+    }
+
+    private static bool StartsWithSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
     {
         if (pathSegments.Count < candidateSegments.Count)
         {
             return false;
         }
 
-        for (var startIndex = 0; startIndex <= pathSegments.Count - candidateSegments.Count; startIndex++)
+        for (var i = 0; i < candidateSegments.Count; i++)
         {
-            var matches = true;
-            for (var i = 0; i < candidateSegments.Count; i++)
+            if (!SegmentMatches(pathSegments[i], candidateSegments[i]))
             {
-                if (!SegmentMatches(pathSegments[startIndex + i], candidateSegments[i]))
-                {
-                    matches = false;
-                    break;
-                }
-            }
-
-            if (matches)
-            {
-                return true;
+                return false;
             }
         }
 
-        return false;
+        return true;
+    }
+
+    private static bool EndsWithSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
+    {
+        if (pathSegments.Count < candidateSegments.Count)
+        {
+            return false;
+        }
+
+        var startIndex = pathSegments.Count - candidateSegments.Count;
+        for (var i = 0; i < candidateSegments.Count; i++)
+        {
+            if (!SegmentMatches(pathSegments[startIndex + i], candidateSegments[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool SegmentMatches(string actualSegment, string candidateSegment)

--- a/Services/Scope/TargetAssemblyScopeFilter.cs
+++ b/Services/Scope/TargetAssemblyScopeFilter.cs
@@ -67,7 +67,7 @@ public sealed class TargetAssemblyScopeFilter
             return false;
         }
 
-        if (IsResolverOnlyPath(fullPath, effectiveRoots) || IsUnderAny(fullPath, config.ExcludedTargetRoots))
+        if (IsUnderAny(fullPath, config.ExcludedTargetRoots))
         {
             return false;
         }
@@ -84,67 +84,6 @@ public sealed class TargetAssemblyScopeFilter
 
         var pathSegments = path.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
         return ResolverOnlySegmentSequences.Any(sequence => EndsWithSegmentSequence(pathSegments, sequence));
-    }
-
-    private static bool IsResolverOnlyPath(string path, IEnumerable<string> effectiveRoots)
-    {
-        foreach (var root in effectiveRoots)
-        {
-            if (string.IsNullOrWhiteSpace(root))
-            {
-                continue;
-            }
-
-            var normalizedRoot = Normalize(root);
-            if (!IsUnderRoot(path, normalizedRoot))
-            {
-                continue;
-            }
-
-            var rootSegments = normalizedRoot.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-            if (ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(rootSegments, sequence)))
-            {
-                return true;
-            }
-
-            var relativePath = Path.GetRelativePath(normalizedRoot, path);
-            var relativeSegments = relativePath.Split(['\\', '/'], StringSplitOptions.RemoveEmptyEntries);
-            if (ResolverOnlySegmentSequences.Any(sequence => ContainsSegmentSequence(relativeSegments, sequence)))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static bool ContainsSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)
-    {
-        if (pathSegments.Count < candidateSegments.Count)
-        {
-            return false;
-        }
-
-        for (var i = 0; i <= pathSegments.Count - candidateSegments.Count; i++)
-        {
-            var matched = true;
-
-            for (var j = 0; j < candidateSegments.Count; j++)
-            {
-                if (!SegmentMatches(pathSegments[i + j], candidateSegments[j]))
-                {
-                    matched = false;
-                    break;
-                }
-            }
-
-            if (matched)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static bool EndsWithSegmentSequence(IReadOnlyList<string> pathSegments, IReadOnlyList<string> candidateSegments)

--- a/Services/ThreatVerdictBuilder.cs
+++ b/Services/ThreatVerdictBuilder.cs
@@ -12,9 +12,8 @@ namespace MLVScan.Services
     /// </summary>
     public class ThreatVerdictBuilder
     {
-        private const double KnownFamilyBypassThreshold = 0.95d;
-
         private readonly ThreatFamilyClassifier _classifier = new ThreatFamilyClassifier();
+        private readonly ThreatDispositionClassifier _dispositionClassifier = new ThreatDispositionClassifier();
 
         public ScannedPluginResult Build(string filePath, string fileHash, List<ScanFinding> findings)
         {
@@ -35,6 +34,7 @@ namespace MLVScan.Services
         private ThreatVerdictInfo BuildVerdict(List<ScanFinding> findings, string fileHash)
         {
             var matches = _classifier.Classify(findings, fileHash).ToList();
+            var disposition = _dispositionClassifier.Classify(findings, matches);
             var families = matches.Select(MapFamily).ToList();
             var primaryFamily = families
                 .OrderByDescending(f => f.ExactHashMatch)
@@ -42,41 +42,42 @@ namespace MLVScan.Services
                 .ThenBy(f => f.DisplayName, StringComparer.Ordinal)
                 .FirstOrDefault();
 
-            if (primaryFamily?.ExactHashMatch == true)
+            if (disposition.Classification == ThreatDispositionClassification.KnownThreat &&
+                primaryFamily?.ExactHashMatch == true)
             {
                 return new ThreatVerdictInfo
                 {
                     Kind = ThreatVerdictKind.KnownMaliciousSample,
                     Title = "Known malicious sample match",
-                    Summary = "This file exactly matches a previously confirmed malicious sample and was blocked before execution.",
+                    Summary = "This mod is likely malware because it exactly matches a previously confirmed malicious sample and was blocked before execution.",
                     Confidence = 1.0d,
-                    ShouldBypassThreshold = true,
+                    ShouldBypassThreshold = false,
                     PrimaryFamily = primaryFamily,
                     Families = families
                 };
             }
 
-            if (primaryFamily != null && primaryFamily.Confidence >= KnownFamilyBypassThreshold)
+            if (disposition.Classification == ThreatDispositionClassification.KnownThreat && primaryFamily != null)
             {
                 return new ThreatVerdictInfo
                 {
                     Kind = ThreatVerdictKind.KnownMalwareFamily,
                     Title = "Known malware family match",
-                    Summary = $"This mod matches the previously analyzed malware family \"{primaryFamily.DisplayName}\" and was blocked before execution.",
+                    Summary = $"This mod is likely malware because it matches the previously analyzed malware family \"{primaryFamily.DisplayName}\" and was blocked before execution.",
                     Confidence = primaryFamily.Confidence,
-                    ShouldBypassThreshold = true,
+                    ShouldBypassThreshold = false,
                     PrimaryFamily = primaryFamily,
                     Families = families
                 };
             }
 
-            if (findings.Count > 0)
+            if (disposition.Classification == ThreatDispositionClassification.Suspicious)
             {
                 return new ThreatVerdictInfo
                 {
                     Kind = ThreatVerdictKind.Suspicious,
                     Title = "Suspicious mod",
-                    Summary = "This mod triggered suspicious behavior patterns and was blocked as a precaution. It may still require human review.",
+                    Summary = "This mod triggered correlated suspicious behavior and was blocked as a precaution. It may still be a false positive and should be reviewed before assuming infection.",
                     Confidence = 0d,
                     ShouldBypassThreshold = false,
                     PrimaryFamily = primaryFamily,

--- a/Services/ThreatVerdictTextFormatter.cs
+++ b/Services/ThreatVerdictTextFormatter.cs
@@ -7,13 +7,48 @@ using MLVScan.Models;
 namespace MLVScan.Services
 {
     /// <summary>
-    /// Shared formatting helpers for threat verdict console output and report sections.
+    /// Shared formatting helpers for scan outcome console output and report sections.
     /// </summary>
     public static class ThreatVerdictTextFormatter
     {
         public static string GetVerdictLabel(ThreatVerdictInfo threatVerdict)
         {
             return (threatVerdict?.Title ?? string.Empty).Trim();
+        }
+
+        public static string GetScanStatusLabel(ScanStatusInfo scanStatus)
+        {
+            return (scanStatus?.Title ?? string.Empty).Trim();
+        }
+
+        public static string GetOutcomeLabel(ScannedPluginResult scanResult)
+        {
+            if (ScanResultFacts.HasThreatVerdict(scanResult))
+            {
+                return GetVerdictLabel(scanResult.ThreatVerdict);
+            }
+
+            if (ScanResultFacts.RequiresManualReview(scanResult))
+            {
+                return GetScanStatusLabel(scanResult.ScanStatus);
+            }
+
+            return string.Empty;
+        }
+
+        public static string GetOutcomeSummary(ScannedPluginResult scanResult)
+        {
+            if (ScanResultFacts.HasThreatVerdict(scanResult))
+            {
+                return scanResult?.ThreatVerdict?.Summary ?? string.Empty;
+            }
+
+            if (ScanResultFacts.RequiresManualReview(scanResult))
+            {
+                return scanResult?.ScanStatus?.Summary ?? string.Empty;
+            }
+
+            return string.Empty;
         }
 
         public static string GetPrimaryFamilyLabel(ThreatVerdictInfo threatVerdict)
@@ -109,6 +144,19 @@ namespace MLVScan.Services
                 }
             }
 
+            writer.WriteLine();
+        }
+
+        public static void WriteScanStatusSection(TextWriter writer, ScanStatusInfo scanStatus)
+        {
+            if (writer == null || scanStatus == null || scanStatus.Kind == ScanStatusKind.Complete)
+            {
+                return;
+            }
+
+            writer.WriteLine("Scan Status:");
+            writer.WriteLine($"- Status: {scanStatus.Title}");
+            writer.WriteLine($"- Summary: {scanStatus.Summary}");
             writer.WriteLine();
         }
     }


### PR DESCRIPTION
## Summary

This PR begins the loader-side transition from broad severity-based blocking to the newer threat disposition model, where confirmed malware families and known malicious patterns become the primary basis for blocking decisions.

The goal is to improve day-to-day accuracy by dramatically reducing false positives while keeping protection strong. The existing rule system is still part of the pipeline and still powers detection internally, but loader-facing verdict handling is moving toward more reliable disposition and family-based outcomes instead of treating every isolated High or Critical rule hit as an automatic block.

This PR also includes loader startup optimizations focused on the biggest hotspots found during profiling, especially repeated file hashing and repeated Mono.Cecil resolver directory searches.

## Changes

- begin migrating MelonLoader and BepInEx integrations from raw severity-based blocking to threat disposition and family-aware verdict handling
- update loader config, reporting, consent, and plugin disabling flows to align with the new disposition model
- preserve the existing rule pipeline as the underlying signal source for families and malware classification
- restore exact-hash detection on scanned files even when rule findings are otherwise empty
- add a strict local scan cache for unchanged clean and flagged assemblies
- validate cache reuse against scanner fingerprint, resolver context, and cross-platform file identity
- fall back to SHA256 verification or full rescan when file identity cannot be trusted
- replace repeated broad Cecil search-directory resolution with an indexed resolver/catalog
- tighten scan root discovery so loader scan scope is more deterministic
- add compile-gated profiling hooks for measuring hashing, cache, resolver, and scan costs

## Why

MLVScan has historically relied heavily on rule severity, where certain High or Critical detections often resulted in automatic blocking. That catches real threats, but it also creates noise when heuristic signals are strong enough to look dangerous without matching a known malware pattern.

This branch moves the loaders toward the intended long-term model: prioritize accurate blocking based on confirmed malware families and reused malicious behavior patterns, while still keeping the lower-level rules in place as supporting intelligence. In practice, that should mean fewer false alarms and a cleaner user experience without dropping the scanner’s ability to catch malware that is already known and actively reused.

The performance work in this PR supports that shift by reducing repeated startup cost in the loader integrations, especially on warm scans.

## Security Notes

- cache trust remains local-only; no remote hash lookup is introduced
- cache entries are authenticated and rejected if invalid, stale, tampered, or mismatched
- unchanged-file reuse only happens when identity and scan context still match
- weaker identity cases degrade to verification or full rescan instead of optimistic reuse
- no multithreaded scanning was introduced in this change set

## Notes

This is the beginning of the loader migration, not the final state of the overall detection model. The intent is to preserve the protection MLVScan already has while making blocking decisions more accurate, more explainable, and less noisy for normal users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Release Notes

- Migrated MelonLoader and BepInEx loader integrations from severity-based blocking to a threat-disposition and family-aware verdict model
- Restored exact-hash detection for scanned files even when rule findings are empty
- Added a strict local scan cache with cryptographic signing, atomic writes, tamper detection, and cache pruning
- Validated cache reuse against scanner fingerprint, resolver context, and cross-platform file identity (Windows strong identity; Unix weaker fallback to SHA256 or full rescan)
- Replaced repeated Mono.Cecil directory searches with an indexed resolver/catalog and added CatalogingAssemblyResolverProviderBase for stable resolver roots and context fingerprints
- Tightened scan-root discovery and path-segmentation rules to make scan scope more deterministic and reduce false positives
- Moved plugin-disabling decisions to ThreatVerdictKind-based logic with configurable BlockKnownThreats/BlockSuspicious toggles
- Updated consent/reporting flows to persist pending verdict kind metadata and show dynamic consent messages based on verdict kind
- Improved reporting language to distinguish "likely malware" (known threats) from "suspicious correlated behavior" (potential false positives)
- Added platform-aware cross-platform file identity provider, ScanCache models, secure cache store, and envelope codec for on-disk cache format
- Added compile-gated profiling (MLVSCAN_PROFILING) and a loader scan telemetry hub to measure hashing, cache, resolver, and scan costs
- Security notes: cache trust is local-only; entries are verified and rejected if invalid/stale/tampered/mismatched; weaker identity cases degrade to verification/full rescan; no multithreaded scanning introduced

## Contribution Summary

| Author | Added | Removed |
|--------|------:|--------:|
| ifBars | 1,857 | 704 |
| renovate[bot] | 10 | 4 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->